### PR TITLE
Add MATLAB Simulink starter example

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,17 @@
+## Summary
+
+Describe the MATLAB/Simulink example or documentation change.
+
+## Modeling Value
+
+- [ ] Adds a reproducible example.
+- [ ] Clarifies assumptions.
+- [ ] Improves setup instructions.
+- [ ] Adds validation or expected-output notes.
+
+## Validation
+
+- [ ] Units are stated.
+- [ ] Required MATLAB products are listed.
+- [ ] Expected results are described.
+- [ ] No generated artifacts are committed unless they are intentionally documented.

--- a/.github/workflows/markdown-maintenance.yml
+++ b/.github/workflows/markdown-maintenance.yml
@@ -1,0 +1,23 @@
+name: Markdown maintenance
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - "**.md"
+
+permissions:
+  contents: read
+
+jobs:
+  link-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Check Markdown links
+        uses: lycheeverse/lychee-action@v2
+        with:
+          args: --verbose --no-progress README.md CONTRIBUTING.md notes/*.md examples/*/README.md
+          fail: true

--- a/README.md
+++ b/README.md
@@ -9,6 +9,11 @@ Reproducible MATLAB and Simulink examples for batteries, converters, power elect
 - Use clear plots, units, and validation notes.
 - Connect simulations to practical engineering questions.
 
+## Starter Content
+
+- [Battery RC model example scaffold](examples/battery-rc-model/README.md)
+- [Modeling standards](notes/modeling-standards.md)
+
 ## Repository Topics
 
 ```text

--- a/examples/battery-rc-model/README.md
+++ b/examples/battery-rc-model/README.md
@@ -1,0 +1,35 @@
+# Battery RC Model Example
+
+This starter example outlines a simple battery equivalent-circuit model for future MATLAB/Simulink implementation.
+
+## Engineering Question
+
+How can a first-order RC equivalent circuit help explain terminal-voltage response during charge and discharge pulses?
+
+## Model Scope
+
+| Element | Meaning |
+|---|---|
+| `OCV(SOC)` | Open-circuit voltage as a function of state of charge |
+| `R0` | Ohmic resistance |
+| `R1-C1` | Transient polarization branch |
+| `I` | Applied current profile |
+| `Vt` | Terminal voltage |
+
+## Planned MATLAB Files
+
+```text
+examples/battery-rc-model/
+  README.md
+  run_battery_rc_model.m
+  data/
+    pulse_current_profile.csv
+  results/
+    terminal_voltage_plot.png
+```
+
+## Validation Notes
+
+- State units for every parameter.
+- Compare simulated terminal voltage with a known pulse response.
+- Report assumptions around temperature and SOC range.

--- a/notes/modeling-standards.md
+++ b/notes/modeling-standards.md
@@ -1,0 +1,24 @@
+# Modeling Standards
+
+Use these standards for examples in this repository.
+
+## Minimum Example Requirements
+
+| Requirement | Why It Matters |
+|---|---|
+| Clear engineering question | Keeps examples tied to practical value |
+| Assumption table | Prevents simulation results from looking stronger than they are |
+| Units on all parameters | Makes results reproducible |
+| Expected output | Helps readers know whether the example ran correctly |
+| Validation note | Separates demonstration from verified model |
+
+## README Pattern
+
+Each example should include:
+
+- Engineering question.
+- Model scope.
+- Required products/toolboxes.
+- How to run.
+- Expected output.
+- Validation limits.


### PR DESCRIPTION
## Summary

Adds starter MATLAB/Simulink energy-lab content and maintenance structure.

## Changes

- Battery RC model example scaffold.
- Modeling standards note.
- PR template.
- Markdown maintenance workflow.

## Validation

- git diff --check passed locally before commit.