### PR TITLE
Add converter average model scaffold

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Reproducible MATLAB and Simulink examples for batteries, converters, power elect
 ## Starter Content
 
 - [Battery RC model example scaffold](examples/battery-rc-model/README.md)
+- [Converter average model scaffold](examples/converter-average-model/README.md)
 - [Modeling standards](notes/modeling-standards.md)
 
 ## Repository Topics
@@ -39,4 +40,4 @@ LICENSE
 - Add a first executable MATLAB RC-model script.
 - Extend the sample pulse-current CSV file.
 - Add automated checks for future MATLAB examples.
-- Add a converter example scaffold.
+- Extend the converter example scaffold with validation notes.

--- a/examples/converter-average-model/README.md
+++ b/examples/converter-average-model/README.md
@@ -1,0 +1,53 @@
+# Converter Average Model Scaffold
+
+This scaffold captures assumptions and signals for a simple averaged DC-DC converter example. It is intentionally small so the model intent can be reviewed before a detailed switching or Simulink implementation is added.
+
+## Engineering Question
+
+How can an averaged converter model estimate output voltage, inductor current, and capacitor ripple for a first-pass power-electronics study?
+
+## Starter Assumptions
+
+| Parameter | Symbol | Starter Value | Unit | Note |
+|---|---|---|---|---|
+| Input voltage | `Vdc` | 800 | V | DC source or battery-side voltage. |
+| Duty cycle | `D` | 0.45 | - | Placeholder command for average model. |
+| Switching frequency | `fsw` | 10000 | Hz | Used for ripple estimates only. |
+| Inductance | `L` | 0.002 | H | Starter inductor value. |
+| Capacitance | `C` | 0.001 | F | Starter DC-link or output capacitance. |
+| Load resistance | `Rload` | 20 | Ohm | Simple resistive load placeholder. |
+
+## Signal List
+
+| Signal | Meaning |
+|---|---|
+| `input_voltage_V` | DC input voltage used by the averaged converter estimate. |
+| `duty_cycle` | Control command for the averaged conversion ratio. |
+| `output_voltage_V` | Estimated average output voltage. |
+| `inductor_current_A` | Estimated load-side current. |
+| `estimated_current_ripple_A` | Simple first-pass ripple estimate. |
+
+## How To Run
+
+Open MATLAB, navigate to this folder, and run:
+
+```matlab
+run_converter_average_model
+```
+
+Expected starter output:
+
+```text
+Converter average model scaffold
+Input voltage: 800.0 V
+Duty cycle: 0.45
+Estimated output voltage: 360.0 V
+Estimated load current: 18.0 A
+```
+
+## Next Steps
+
+- Replace placeholder assumptions with project or datasheet values.
+- Add parameter validation and operating-limit checks.
+- Compare the averaged estimate with a switching model or measured waveform.
+- Document whether the intended topology is buck, boost, bidirectional, or isolated.

--- a/examples/converter-average-model/run_converter_average_model.m
+++ b/examples/converter-average-model/run_converter_average_model.m
@@ -1,0 +1,27 @@
+%% Converter Average Model Scaffold
+% Prints starter assumptions and first-pass averaged estimates without plotting.
+
+clear; clc;
+
+input_voltage_V = 800;
+duty_cycle = 0.45;
+switching_frequency_Hz = 10000;
+inductance_H = 0.002;
+capacitance_F = 0.001;
+load_resistance_Ohm = 20;
+
+output_voltage_V = duty_cycle * input_voltage_V;
+inductor_current_A = output_voltage_V / load_resistance_Ohm;
+estimated_current_ripple_A = (input_voltage_V - output_voltage_V) * duty_cycle / ...
+    (inductance_H * switching_frequency_Hz);
+estimated_voltage_ripple_V = estimated_current_ripple_A / ...
+    (8 * switching_frequency_Hz * capacitance_F);
+
+fprintf('Converter average model scaffold\n');
+fprintf('Input voltage: %.1f V\n', input_voltage_V);
+fprintf('Duty cycle: %.2f\n', duty_cycle);
+fprintf('Switching frequency: %.0f Hz\n', switching_frequency_Hz);
+fprintf('Estimated output voltage: %.1f V\n', output_voltage_V);
+fprintf('Estimated load current: %.1f A\n', inductor_current_A);
+fprintf('Estimated current ripple: %.2f A\n', estimated_current_ripple_A);
+fprintf('Estimated voltage ripple: %.3f V\n', estimated_voltage_ripple_V);


### PR DESCRIPTION
## Summary
- add a converter average model example scaffold
- include assumptions, signal list, and a no-plot MATLAB starter script
- link the example from the top-level README

Closes #7.

## Validation
- git diff --check
- MATLAB R2026a batch: run_converter_average_model