### PR TITLE
Add MATLAB examples index

### DIFF
--- a/.github/workflows/markdown-maintenance.yml
+++ b/.github/workflows/markdown-maintenance.yml
@@ -19,5 +19,5 @@ jobs:
       - name: Check Markdown links
         uses: lycheeverse/lychee-action@v2
         with:
-          args: --verbose --no-progress README.md CONTRIBUTING.md notes/*.md examples/*/README.md
+          args: --verbose --no-progress README.md CONTRIBUTING.md notes/*.md examples/README.md examples/*/README.md
           fail: true

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Reproducible MATLAB and Simulink examples for batteries, converters, power elect
 
 ## Starter Content
 
+- [MATLAB examples index](examples/README.md)
 - [Battery RC model example scaffold](examples/battery-rc-model/README.md)
 - [Converter average model scaffold](examples/converter-average-model/README.md)
 - [Modeling standards](notes/modeling-standards.md)
@@ -37,6 +38,7 @@ LICENSE
 
 ## Contribution Entry Points
 
+- Add a new example to the MATLAB examples index.
 - Add a first executable MATLAB RC-model script.
 - Extend the sample pulse-current CSV file.
 - Add automated checks for future MATLAB examples.

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,15 @@
+# MATLAB Examples Index
+
+This index lists the starter MATLAB examples, their purpose, key files, and run commands.
+
+| Example | Purpose | Key Files | Run Commands |
+|---|---|---|---|
+| [Battery RC model](battery-rc-model/README.md) | Demonstrates a small first-order battery equivalent-circuit model with current, SOC, and terminal-voltage outputs. | `battery-rc-model/run_battery_rc_model.m`, `battery-rc-model/check_battery_rc_model.m`, `battery-rc-model/data/pulse_current_profile.csv` | `run_battery_rc_model`, `check_battery_rc_model` |
+| [Converter average model](converter-average-model/README.md) | Provides a no-plot averaged converter scaffold for assumptions, signal naming, and first-pass estimates. | `converter-average-model/run_converter_average_model.m`, `converter-average-model/check_converter_average_model.m` | `run_converter_average_model`, `check_converter_average_model` |
+
+## Review Use
+
+- Start with the example README before running a script.
+- Run no-plot checks when validating assumptions or preparing automation.
+- Treat placeholder values as educational scaffolds until replaced with project, datasheet, or measured parameters.
+- Keep expected output notes updated whenever model assumptions change.


### PR DESCRIPTION
## Summary
- add a MATLAB examples index covering the battery RC and converter average model examples
- link the index from the top-level README
- include the new index in Markdown maintenance checks

Closes #13.

## Validation
- git diff --check
- MATLAB R2026a batch: check_battery_rc_model; check_converter_average_model