### PR TITLE
Add MATLAB example maintenance checklist

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -29,3 +29,15 @@ check_converter_average_model
 ```
 
 The plotting scripts, `run_battery_rc_model` and `run_converter_average_model`, are intended for visual inspection and explanation. Use the no-plot checks for quick validation before future automation.
+
+## Maintenance Checklist
+
+| Check | Why It Matters |
+|---|---|
+| Assumptions are listed before results | Reviewers should see placeholder values before trusting outputs. |
+| Units are stated for parameters and outputs | MATLAB examples are easier to inspect when units are explicit. |
+| Expected output is documented | Small examples should make intentional output changes obvious. |
+| No-plot check exists | Future automation needs a fast validation command. |
+| Plotting script remains inspectable | Visual scripts should explain behavior without hiding logic in large helpers. |
+| Sample data is small and local | Examples should run without private files or external downloads. |
+| Validation note is updated after model changes | Documentation should change when assumptions or outputs change. |


### PR DESCRIPTION
## Summary
- add a MATLAB example maintenance checklist
- cover assumptions, units, expected output, no-plot checks, plotting scripts, sample data, and validation notes
- keep the checklist in the examples index

Closes #17.

## Validation
- git diff --check
- MATLAB R2026a batch: check_battery_rc_model; check_converter_average_model