### PR TITLE
Add MATLAB example output inventory

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -7,6 +7,15 @@ This index lists the starter MATLAB examples, their purpose, key files, and run 
 | [Battery RC model](battery-rc-model/README.md) | Demonstrates a small first-order battery equivalent-circuit model with current, SOC, and terminal-voltage outputs. | `battery-rc-model/run_battery_rc_model.m`, `battery-rc-model/check_battery_rc_model.m`, `battery-rc-model/data/pulse_current_profile.csv` | `run_battery_rc_model`, `check_battery_rc_model` |
 | [Converter average model](converter-average-model/README.md) | Provides a no-plot averaged converter scaffold for assumptions, signal naming, and first-pass estimates. | `converter-average-model/run_converter_average_model.m`, `converter-average-model/check_converter_average_model.m` | `run_converter_average_model`, `check_converter_average_model` |
 
+## Output Inventory
+
+| Script | Expected Output |
+|---|---|
+| `battery-rc-model/check_battery_rc_model.m` | Prints `Battery RC check passed. Final SOC: 0.767` and voltage range `3.425 V to 3.877 V`. |
+| `battery-rc-model/run_battery_rc_model.m` | Prints final SOC and voltage range, and opens current, SOC, and terminal-voltage plots. |
+| `converter-average-model/check_converter_average_model.m` | Prints `Converter parameter check passed.`, output voltage `360.0 V`, and load current `18.0 A`. |
+| `converter-average-model/run_converter_average_model.m` | Prints converter scaffold assumptions and first-pass output, current ripple, and voltage ripple estimates. |
+
 ## Review Use
 
 - Start with the example README before running a script.


### PR DESCRIPTION
## Summary
- add an expected output inventory to the MATLAB examples index
- include printed values and qualitative plotting outputs for each starter script
- keep output notes aligned with existing example READMEs

Closes #19.

## Validation
- git diff --check
- MATLAB R2026a batch: check_battery_rc_model; check_converter_average_model