### PR TITLE
Add MATLAB assumptions checklist

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -50,3 +50,14 @@ The plotting scripts, `run_battery_rc_model` and `run_converter_average_model`, 
 | Plotting script remains inspectable | Visual scripts should explain behavior without hiding logic in large helpers. |
 | Sample data is small and local | Examples should run without private files or external downloads. |
 | Validation note is updated after model changes | Documentation should change when assumptions or outputs change. |
+
+## Assumptions Checklist
+
+| Check | Prompt |
+|---|---|
+| Parameter units | Are all parameters labeled with units in the README or script comments? |
+| Placeholder values | Are educational placeholder values clearly separated from sourced project values? |
+| Sample data | Is sample input data small, local, and safe to run in automation? |
+| Solver or time step | Does the example explain the chosen time step or simplified solver assumption? |
+| Expected output | Does the documented output match the current no-plot check? |
+| Validation command | Can a reviewer run one short command to confirm the example still works? |


### PR DESCRIPTION
## Summary
- Add an assumptions checklist to the MATLAB examples index for units, placeholders, sample data, solver choices, expected output, and validation commands.

Closes #21

## Validation
- git diff --check
- matlab -batch "cd('C:/Users/MRKhan/OneDrive/Documents2/misC/github-profile-loop-2/starter-repos/matlab-simulink-energy-lab/examples/battery-rc-model'); check_battery_rc_model; cd('C:/Users/MRKhan/OneDrive/Documents2/misC/github-profile-loop-2/starter-repos/matlab-simulink-energy-lab/examples/converter-average-model'); check_converter_average_model"
