### PR TITLE
Add MATLAB example troubleshooting notes

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -7,6 +7,10 @@ This index lists the starter MATLAB examples, their purpose, key files, and run 
 | [Battery RC model](battery-rc-model/README.md) | Demonstrates a small first-order battery equivalent-circuit model with current, SOC, and terminal-voltage outputs. | `battery-rc-model/run_battery_rc_model.m`, `battery-rc-model/check_battery_rc_model.m`, `battery-rc-model/data/pulse_current_profile.csv` | `run_battery_rc_model`, `check_battery_rc_model` |
 | [Converter average model](converter-average-model/README.md) | Provides a no-plot averaged converter scaffold for assumptions, signal naming, and first-pass estimates. | `converter-average-model/run_converter_average_model.m`, `converter-average-model/check_converter_average_model.m` | `run_converter_average_model`, `check_converter_average_model` |
 
+## Example Guides
+
+- [Example troubleshooting notes](guides/example-troubleshooting-notes.md)
+
 ## Output Inventory
 
 | Script | Expected Output |

--- a/examples/guides/example-troubleshooting-notes.md
+++ b/examples/guides/example-troubleshooting-notes.md
@@ -1,0 +1,17 @@
+# Example Troubleshooting Notes
+
+Use these notes to triage common run, path, data, and expected-output problems in the MATLAB examples.
+
+| Symptom | Likely Cause | First Check | Recovery Action |
+|---|---|---|---|
+| Script cannot find a data file | MATLAB is running from the wrong folder | Confirm the current folder is the example directory | Change into the example folder or use the documented run command |
+| Expected output changed | Parameter, sample data, or calculation logic changed | Run the matching no-plot check | Update the README only after confirming the change is intentional |
+| Plot opens but values look unrealistic | Units or placeholder parameters were edited | Compare parameter units against the example README | Restore the starter value or document the new source |
+| Check script fails after a documentation edit | Expected output text no longer matches behavior | Run the example manually and inspect printed values | Update the check and output inventory together |
+| Example works locally but not in automation | Hidden dependency, path assumption, or external file was introduced | Review required files and products | Keep sample data local and document required MATLAB products |
+
+## Review Prompts
+
+- Can a reviewer reproduce the problem from a fresh clone?
+- Does the failure point to data, assumptions, path setup, or expected output?
+- Is the troubleshooting note short enough to help without hiding the actual model logic?


### PR DESCRIPTION
## Summary
- Add MATLAB example troubleshooting notes for common run, path, data, and expected-output problems.
- Link the guide from the examples index.

Closes #23

## Validation
- git diff --check
- matlab -batch "cd('C:/Users/MRKhan/OneDrive/Documents2/misC/github-profile-loop-2/starter-repos/matlab-simulink-energy-lab/examples/battery-rc-model'); check_battery_rc_model; cd('C:/Users/MRKhan/OneDrive/Documents2/misC/github-profile-loop-2/starter-repos/matlab-simulink-energy-lab/examples/converter-average-model'); check_converter_average_model"
