### PR TITLE
Add MATLAB validation error triage

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -25,6 +25,8 @@ This index lists the starter MATLAB examples, their purpose, key files, and run 
 
 - [Unit Consistency Checklist](guides/unit-consistency-checklist.md)
 
+- [Validation Error Triage](guides/validation-error-triage.md)
+
 ## Output Inventory
 
 | Script | Expected Output |

--- a/examples/guides/validation-error-triage.md
+++ b/examples/guides/validation-error-triage.md
@@ -1,0 +1,18 @@
+# Validation Error Triage
+
+Use this guide for separating expected-output drift, parameter errors, and environment problems during checks. It is written for small MATLAB and Simulink examples that should remain easy to run, inspect, and validate.
+
+| Review Area | Prompt | Expected Record |
+|---|---|---|
+| Purpose | What engineering question does the example answer? | One short purpose statement in the README. |
+| Inputs | Which parameters, sample data, or assumptions drive the result? | Source, units, and placeholder status. |
+| Execution | What command should a reviewer run first? | A short no-plot command when possible. |
+| Output | What text, value, or plot should change if the example changes? | Expected output note or check result. |
+| Maintenance | What documentation must be updated with the code? | README, validation command, and assumptions note. |
+
+## Review Prompts
+
+- Can the example run from a fresh clone without private files?
+- Are teaching simplifications clearly separated from project-ready assumptions?
+- Would a failed check point to the likely cause quickly?
+- Does the guide keep the example small enough for review?


### PR DESCRIPTION
## Summary
- Add Validation Error Triage for separating expected-output drift, parameter errors, and environment problems during checks.
- Link the artifact from the repository index.

Closes #39

## Validation
- git diff --check- matlab -batch "cd('C:/Users/MRKhan/OneDrive/Documents2/misC/github-profile-loop-2/starter-repos/matlab-simulink-energy-lab/examples/battery-rc-model'); check_battery_rc_model; cd('C:/Users/MRKhan/OneDrive/Documents2/misC/github-profile-loop-2/starter-repos/matlab-simulink-energy-lab/examples/converter-average-model'); check_converter_average_model"
