### PR TITLE
Add MATLAB small model extension plan

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -27,6 +27,8 @@ This index lists the starter MATLAB examples, their purpose, key files, and run 
 
 - [Validation Error Triage](guides/validation-error-triage.md)
 
+- [Small Model Extension Plan](guides/small-model-extension-plan.md)
+
 ## Output Inventory
 
 | Script | Expected Output |

--- a/examples/guides/small-model-extension-plan.md
+++ b/examples/guides/small-model-extension-plan.md
@@ -1,0 +1,18 @@
+# Small Model Extension Plan
+
+Use this guide for planning small, reviewable example extensions without making starter models too large. It is written for small MATLAB and Simulink examples that should remain easy to run, inspect, and validate.
+
+| Review Area | Prompt | Expected Record |
+|---|---|---|
+| Purpose | What engineering question does the example answer? | One short purpose statement in the README. |
+| Inputs | Which parameters, sample data, or assumptions drive the result? | Source, units, and placeholder status. |
+| Execution | What command should a reviewer run first? | A short no-plot command when possible. |
+| Output | What text, value, or plot should change if the example changes? | Expected output note or check result. |
+| Maintenance | What documentation must be updated with the code? | README, validation command, and assumptions note. |
+
+## Review Prompts
+
+- Can the example run from a fresh clone without private files?
+- Are teaching simplifications clearly separated from project-ready assumptions?
+- Would a failed check point to the likely cause quickly?
+- Does the guide keep the example small enough for review?


### PR DESCRIPTION
## Summary
- Add Small Model Extension Plan for planning small, reviewable example extensions without making starter models too large.
- Link the artifact from the repository index.

Closes #41

## Validation
- git diff --check- matlab -batch "cd('C:/Users/MRKhan/OneDrive/Documents2/misC/github-profile-loop-2/starter-repos/matlab-simulink-energy-lab/examples/battery-rc-model'); check_battery_rc_model; cd('C:/Users/MRKhan/OneDrive/Documents2/misC/github-profile-loop-2/starter-repos/matlab-simulink-energy-lab/examples/converter-average-model'); check_converter_average_model"
