### PR TITLE
Add MATLAB dependency inventory guide

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -39,6 +39,8 @@ This index lists the starter MATLAB examples, their purpose, key files, and run 
 
 - [Assumptions To Tests Map](guides/assumptions-to-tests-map.md)
 
+- [Dependency Inventory Guide](guides/dependency-inventory-guide.md)
+
 ## Output Inventory
 
 | Script | Expected Output |

--- a/examples/guides/dependency-inventory-guide.md
+++ b/examples/guides/dependency-inventory-guide.md
@@ -1,0 +1,18 @@
+# Dependency Inventory Guide
+
+Use this guide for identifying required MATLAB products, files, and local data before example publication. It is written for small MATLAB and Simulink examples that should remain easy to run, inspect, and validate.
+
+| Review Area | Prompt | Expected Record |
+|---|---|---|
+| Purpose | What engineering question does the example answer? | One short purpose statement in the README. |
+| Inputs | Which parameters, sample data, or assumptions drive the result? | Source, units, and placeholder status. |
+| Execution | What command should a reviewer run first? | A short no-plot command when possible. |
+| Output | What text, value, or plot should change if the example changes? | Expected output note or check result. |
+| Maintenance | What documentation must be updated with the code? | README, validation command, and assumptions note. |
+
+## Review Prompts
+
+- Can the example run from a fresh clone without private files?
+- Are teaching simplifications clearly separated from project-ready assumptions?
+- Would a failed check point to the likely cause quickly?
+- Does the guide keep the example small enough for review?


### PR DESCRIPTION
## Summary
- Add Dependency Inventory Guide for identifying required MATLAB products, files, and local data before example publication.
- Link the artifact from the repository index.

Closes #53

## Validation
- git diff --check- matlab -batch "cd('C:/Users/MRKhan/OneDrive/Documents2/misC/github-profile-loop-2/starter-repos/matlab-simulink-energy-lab/examples/battery-rc-model'); check_battery_rc_model; cd('C:/Users/MRKhan/OneDrive/Documents2/misC/github-profile-loop-2/starter-repos/matlab-simulink-energy-lab/examples/converter-average-model'); check_converter_average_model"
