### PR TITLE
Add MATLAB example validation CI

### DIFF
--- a/.github/workflows/matlab-validation.yml
+++ b/.github/workflows/matlab-validation.yml
@@ -1,0 +1,43 @@
+name: MATLAB validation
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - "**/*.m"
+      - ".github/workflows/matlab-validation.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "**/*.m"
+      - ".github/workflows/matlab-validation.yml"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: matlab-validation-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  validate-examples:
+    name: Validate executable examples
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Set up MATLAB R2026a
+        uses: matlab-actions/setup-matlab@v3
+        with:
+          release: R2026a
+
+      - name: Run model checks
+        uses: matlab-actions/run-command@v3
+        with:
+          command: >-
+            run('examples/battery-rc-model/check_battery_rc_model.m');
+            run('examples/battery-thermal-model/check_battery_thermal_model.m');
+            run('examples/converter-average-model/check_converter_average_model.m')

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 # ⚡ MATLAB Simulink Energy Lab
 
 [![Markdown maintenance](https://github.com/mohammadrezwankhan/matlab-simulink-energy-lab/actions/workflows/markdown-maintenance.yml/badge.svg)](https://github.com/mohammadrezwankhan/matlab-simulink-energy-lab/actions/workflows/markdown-maintenance.yml)
+[![MATLAB validation](https://github.com/mohammadrezwankhan/matlab-simulink-energy-lab/actions/workflows/matlab-validation.yml/badge.svg)](https://github.com/mohammadrezwankhan/matlab-simulink-energy-lab/actions/workflows/matlab-validation.yml)
 ![MATLAB R2026a](https://img.shields.io/badge/verified-MATLAB%20R2026a-e86e25.svg)
 [![License: MIT](https://img.shields.io/badge/license-MIT-2f6f5e.svg)](LICENSE)
 [![GitHub stars](https://img.shields.io/github/stars/mohammadrezwankhan/matlab-simulink-energy-lab?style=social)](https://github.com/mohammadrezwankhan/matlab-simulink-energy-lab)
@@ -36,7 +37,8 @@ study.
 ## Start in 60 Seconds
 
 The included checks use base MATLAB functionality and were verified with MATLAB
-R2026a.
+R2026a. The MATLAB validation workflow runs the same checks whenever executable
+model code changes.
 
 ```bash
 git clone https://github.com/mohammadrezwankhan/matlab-simulink-energy-lab.git


### PR DESCRIPTION
## Summary

- add a MATLAB R2026a validation workflow for all executable examples
- run the three existing no-plot model checks when MATLAB sources change
- expose validation status in the project README

## Why

The repository documents repeatable model checks, but only Markdown is currently validated in CI. Running the executable checks on each model-code change catches numerical or physical regressions before merge.

## Validation

- `npx --yes prettier --check .github/workflows/matlab-validation.yml`
- `npx --yes markdownlint-cli2 README.md`
- `git diff --check`
- Local MATLAB invocation attempted but unavailable because this machine has no active MATLAB license; the public-repository workflow provides automatic action licensing.