### PR TITLE
Add closed loop converter reference

### DIFF
--- a/.github/workflows/matlab-validation.yml
+++ b/.github/workflows/matlab-validation.yml
@@ -40,4 +40,5 @@ jobs:
           command: >-
             run('examples/battery-rc-model/check_battery_rc_model.m');
             run('examples/battery-thermal-model/check_battery_thermal_model.m');
-            run('examples/converter-average-model/check_converter_average_model.m')
+            run('examples/converter-average-model/check_converter_average_model.m');
+            run('examples/converter-closed-loop-model/check_closed_loop_converter.m')

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ study.
   temperature and temperature-dependent resistance.
 - Validate model behavior from the command line without opening plots.
 - Estimate output voltage, load current, and ripple for an averaged converter.
+- Inspect bounded closed-loop voltage tracking for an averaged buck converter.
 - Trace every parameter, unit, sign convention, and limitation before extending
   a model.
 
@@ -43,7 +44,7 @@ model code changes.
 ```bash
 git clone https://github.com/mohammadrezwankhan/matlab-simulink-energy-lab.git
 cd matlab-simulink-energy-lab
-matlab -batch "run('examples/battery-rc-model/check_battery_rc_model.m'); run('examples/battery-thermal-model/check_battery_thermal_model.m'); run('examples/converter-average-model/check_converter_average_model.m')"
+matlab -batch "run('examples/battery-rc-model/check_battery_rc_model.m'); run('examples/battery-thermal-model/check_battery_thermal_model.m'); run('examples/converter-average-model/check_converter_average_model.m'); run('examples/converter-closed-loop-model/check_closed_loop_converter.m')"
 ```
 
 Expected output:
@@ -59,6 +60,10 @@ Final SOC: 0.608
 Converter parameter check passed.
 Output voltage: 360.0 V
 Load current: 18.0 A
+Closed-loop converter check passed.
+Final average voltage: 399.49 V
+Peak voltage after step: 421.90 V
+Two-percent settling time: 38.6 ms
 ```
 
 To reproduce the plotted battery response above, run:
@@ -74,10 +79,12 @@ run('examples/battery-rc-model/run_battery_rc_model.m')
 | [Battery RC model](examples/battery-rc-model/README.md) | How do charge and discharge pulses affect SOC and terminal voltage in a first-order equivalent circuit? | `check_battery_rc_model.m` | Base MATLAB |
 | [Temperature-aware battery model](examples/battery-thermal-model/README.md) | How do equivalent-circuit losses, ambient cooling, and resistance feedback affect lumped cell temperature? | `check_battery_thermal_model.m` | Base MATLAB |
 | [Converter average model](examples/converter-average-model/README.md) | What do duty cycle and component values imply for average voltage, load current, and first-pass ripple? | `check_converter_average_model.m` | Base MATLAB |
+| [Closed-loop converter](examples/converter-closed-loop-model/README.md) | How does bounded cascaded control track an averaged buck-converter voltage reference? | `check_closed_loop_converter.m` | Base MATLAB |
 
 Current release status: the executable examples are MATLAB scripts. The
-converter example is an algebraic average-model scaffold, not a switching
-simulation. Native Simulink implementations are planned as the lab grows.
+converter references include an algebraic estimate and a dynamic closed-loop
+average model, but not a switching simulation. Native Simulink implementations
+are planned as the lab grows.
 
 ## Why This Lab Is Inspectable
 
@@ -117,6 +124,7 @@ matlab-simulink-energy-lab/
 |   |-- battery-rc-model/           # RC simulation, pulse data, and check
 |   |-- battery-thermal-model/      # Coupled electrical-thermal cell model
 |   |-- converter-average-model/    # Average-model scaffold and check
+|   |-- converter-closed-loop-model/ # Dynamic plant, controller, and check
 |   `-- guides/                     # Reproducibility and review notes
 |-- notes/                          # Repository-wide modeling standards
 |-- CONTRIBUTING.md
@@ -149,7 +157,6 @@ an issue so the compatibility record can grow.
 The most useful next additions are likely to be:
 
 - a higher-order battery model with hysteresis or additional RC branches;
-- closed-loop control around the averaged converter;
 - an averaged-versus-switched converter comparison;
 - measured-data parameter identification and validation; or
 - native Simulink implementations of the reference models.

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,3 +1,5 @@
+<!-- markdownlint-disable MD013 MD060 -->
+
 # MATLAB Examples Index
 
 This index lists the starter MATLAB examples, their purpose, key files, and run commands.
@@ -7,6 +9,7 @@ This index lists the starter MATLAB examples, their purpose, key files, and run 
 | [Battery RC model](battery-rc-model/README.md) | Demonstrates a small first-order battery equivalent-circuit model with current, SOC, and terminal-voltage outputs. | `battery-rc-model/run_battery_rc_model.m`, `battery-rc-model/check_battery_rc_model.m`, `battery-rc-model/data/pulse_current_profile.csv` | `run_battery_rc_model`, `check_battery_rc_model` |
 | [Temperature-aware battery model](battery-thermal-model/README.md) | Couples an RC equivalent circuit to a lumped heat balance with temperature-dependent ohmic resistance. | `battery-thermal-model/run_battery_thermal_model.m`, `battery-thermal-model/check_battery_thermal_model.m` | `run_battery_thermal_model`, `check_battery_thermal_model` |
 | [Converter average model](converter-average-model/README.md) | Provides a no-plot averaged converter scaffold for assumptions, signal naming, and first-pass estimates. | `converter-average-model/run_converter_average_model.m`, `converter-average-model/check_converter_average_model.m` | `run_converter_average_model`, `check_converter_average_model` |
+| [Closed-loop converter](converter-closed-loop-model/README.md) | Simulates bounded cascaded voltage and current control around an averaged buck-converter plant. | `converter-closed-loop-model/simulate_closed_loop_converter.m`, `converter-closed-loop-model/check_closed_loop_converter.m` | `run_closed_loop_converter`, `check_closed_loop_converter` |
 
 ## Example Guides
 
@@ -62,6 +65,8 @@ This index lists the starter MATLAB examples, their purpose, key files, and run 
 | `battery-thermal-model/run_battery_thermal_model.m` | Prints the same thermal summary and opens current, voltage, temperature, and heat-generation plots. |
 | `converter-average-model/check_converter_average_model.m` | Prints `Converter parameter check passed.`, output voltage `360.0 V`, and load current `18.0 A`. |
 | `converter-average-model/run_converter_average_model.m` | Prints converter scaffold assumptions and first-pass output, current ripple, and voltage ripple estimates. |
+| `converter-closed-loop-model/check_closed_loop_converter.m` | Verifies finite states, duty limits, final tracking error, overshoot, and two-percent settling time. |
+| `converter-closed-loop-model/run_closed_loop_converter.m` | Plots the voltage reference and response, current loop, and bounded duty command. |
 
 ## Review Use
 
@@ -89,7 +94,13 @@ cd examples/converter-average-model
 check_converter_average_model
 ```
 
-The plotting scripts, `run_battery_rc_model` and `run_converter_average_model`, are intended for visual inspection and explanation. Use the no-plot checks for quick validation before future automation.
+```matlab
+cd examples/converter-closed-loop-model
+check_closed_loop_converter
+```
+
+The plotting scripts are intended for visual inspection and explanation. Use
+the no-plot checks for quick validation before future automation.
 
 ## Maintenance Checklist
 

--- a/examples/converter-closed-loop-model/README.md
+++ b/examples/converter-closed-loop-model/README.md
@@ -1,0 +1,69 @@
+# Closed-Loop Averaged Converter
+
+This base-MATLAB reference adds bounded closed-loop control to an averaged
+buck-converter plant. It demonstrates how a voltage reference becomes a current
+request and duty-cycle command without introducing switching-device detail or
+requiring a control-system toolbox.
+
+## Engineering Question
+
+How does a cascaded voltage and current controller track a DC voltage step while
+respecting current-reference and duty-cycle limits?
+
+## Model Structure
+
+The plant uses the continuous-conduction averaged buck equations:
+
+```text
+diL/dt = (D * Vin - Vout - RL * iL) / L
+dVout/dt = (iL - Vout / Rload) / C
+```
+
+The outer PI controller converts voltage error into a bounded inductor-current
+reference. A proportional inner current loop converts current error into a duty
+command, with plant-voltage and inductor-resistance feedforward. Conditional
+integration prevents the outer controller from winding up at its current limits.
+
+## Starter Parameters
+
+| Parameter | Value | Unit |
+| --- | ---: | --- |
+| Input voltage | 800 | V |
+| Inductance | 2 | mH |
+| Inductor resistance | 0.1 | Ohm |
+| Capacitance | 1 | mF |
+| Load resistance | 20 | Ohm |
+| Voltage reference | 300 to 400 at 40 ms | V |
+| Current-reference limits | 0 to 40 | A |
+| Duty-cycle limits | 0.05 to 0.95 | - |
+| Simulation step | 10 | microseconds |
+
+## Run
+
+To inspect the voltage, current, and duty-cycle traces:
+
+```matlab
+run_closed_loop_converter
+```
+
+For a no-plot regression check:
+
+```matlab
+check_closed_loop_converter
+```
+
+The check verifies finite states, unidirectional current, duty-limit compliance,
+final voltage error, overshoot, and two-percent settling time.
+
+## Explicit Limitations
+
+- The converter is an averaged buck model, not a switching simulation.
+- Semiconductor losses, dead time, quantization, delays, and measurement noise
+  are excluded.
+- Gains are educational starter values, not a robust stability design for real
+  hardware.
+- The load is fixed and resistive; source and load disturbances are not applied.
+- The explicit Euler step must be reconsidered if plant or controller bandwidth
+  changes.
+- Hardware limits, protection, sensing, and gain margins require independent
+  engineering validation.

--- a/examples/converter-closed-loop-model/check_closed_loop_converter.m
+++ b/examples/converter-closed-loop-model/check_closed_loop_converter.m
@@ -1,0 +1,52 @@
+%% Closed-Loop Averaged Converter Check
+% Runs no-plot assertions for the cascaded voltage and current controller.
+
+clear; clc;
+
+addpath(fileparts(mfilename('fullpath')));
+result = simulate_closed_loop_converter();
+
+assert(all(isfinite(result.output_voltage_V)), ...
+    'Output voltage must remain finite.');
+assert(all(isfinite(result.inductor_current_A)), ...
+    'Inductor current must remain finite.');
+assert(all(result.duty_cycle >= result.minimum_duty_cycle - eps), ...
+    'Duty cycle fell below its configured lower limit.');
+assert(all(result.duty_cycle <= result.maximum_duty_cycle + eps), ...
+    'Duty cycle exceeded its configured upper limit.');
+assert(all(result.inductor_current_A >= 0), ...
+    'Inductor current became negative in the unidirectional example.');
+
+step_mask = result.time_s >= result.reference_step_time_s;
+final_window_mask = result.time_s >= result.time_s(end) - 0.01;
+post_step_voltage_V = result.output_voltage_V(step_mask);
+final_average_voltage_V = mean(result.output_voltage_V(final_window_mask));
+peak_voltage_V = max(post_step_voltage_V);
+
+settling_band_V = 0.02 * result.final_reference_V;
+outside_band = abs(post_step_voltage_V - result.final_reference_V) > ...
+    settling_band_V;
+last_outside_index = find(outside_band, 1, 'last');
+post_step_time_s = result.time_s(step_mask);
+if isempty(last_outside_index)
+    settling_time_s = 0;
+elseif last_outside_index < numel(post_step_time_s)
+    settling_time_s = post_step_time_s(last_outside_index + 1) - ...
+        result.reference_step_time_s;
+else
+    settling_time_s = inf;
+end
+
+assert(abs(final_average_voltage_V - result.final_reference_V) <= 1, ...
+    'Final average voltage must be within 1 V of the reference.');
+assert(peak_voltage_V <= 1.08 * result.final_reference_V, ...
+    'Post-step voltage overshoot exceeded 8 percent.');
+assert(settling_time_s <= 0.05, ...
+    'Voltage did not settle inside the 2 percent band within 50 ms.');
+
+fprintf('Closed-loop converter check passed.\n');
+fprintf('Final average voltage: %.2f V\n', final_average_voltage_V);
+fprintf('Peak voltage after step: %.2f V\n', peak_voltage_V);
+fprintf('Two-percent settling time: %.1f ms\n', 1000 * settling_time_s);
+fprintf('Duty-cycle range: %.3f to %.3f\n', ...
+    min(result.duty_cycle), max(result.duty_cycle));

--- a/examples/converter-closed-loop-model/run_closed_loop_converter.m
+++ b/examples/converter-closed-loop-model/run_closed_loop_converter.m
@@ -1,0 +1,44 @@
+%% Closed-Loop Averaged Converter Example
+% Plots a voltage-reference step, inductor current, and bounded duty command.
+
+clear; clc; close all;
+
+addpath(fileparts(mfilename('fullpath')));
+result = simulate_closed_loop_converter();
+
+figure('Name', 'Closed-Loop Averaged Converter', 'Color', 'w');
+tiledlayout(3, 1, 'TileSpacing', 'compact');
+
+nexttile;
+plot(result.time_s, result.reference_voltage_V, '--', 'LineWidth', 1.2);
+hold on;
+plot(result.time_s, result.output_voltage_V, 'LineWidth', 1.5);
+grid on;
+ylabel('Voltage (V)');
+legend('Reference', 'Output', 'Location', 'southeast');
+title('Averaged buck-converter voltage response');
+
+nexttile;
+plot(result.time_s, result.current_reference_A, '--', 'LineWidth', 1.2);
+hold on;
+plot(result.time_s, result.inductor_current_A, 'LineWidth', 1.5);
+grid on;
+ylabel('Current (A)');
+legend('Reference', 'Inductor', 'Location', 'southeast');
+
+nexttile;
+plot(result.time_s, result.duty_cycle, 'LineWidth', 1.5);
+grid on;
+xlabel('Time (s)');
+ylabel('Duty cycle');
+ylim([0, 1]);
+
+final_window_mask = result.time_s >= result.time_s(end) - 0.01;
+fprintf('Closed-loop averaged converter example\n');
+fprintf('Reference step: 300 V to %.0f V at %.0f ms\n', ...
+    result.final_reference_V, 1000 * result.reference_step_time_s);
+fprintf('Final average voltage: %.2f V\n', ...
+    mean(result.output_voltage_V(final_window_mask)));
+fprintf('Peak voltage after step: %.2f V\n', ...
+    max(result.output_voltage_V(result.time_s >= ...
+    result.reference_step_time_s)));

--- a/examples/converter-closed-loop-model/simulate_closed_loop_converter.m
+++ b/examples/converter-closed-loop-model/simulate_closed_loop_converter.m
@@ -1,0 +1,103 @@
+function result = simulate_closed_loop_converter()
+%SIMULATE_CLOSED_LOOP_CONVERTER Simulate a cascaded averaged buck controller.
+
+input_voltage_V = 800;
+inductance_H = 0.002;
+inductor_resistance_Ohm = 0.1;
+capacitance_F = 0.001;
+load_resistance_Ohm = 20;
+
+initial_reference_V = 300;
+final_reference_V = 400;
+reference_step_time_s = 0.04;
+end_time_s = 0.12;
+time_step_s = 1e-5;
+
+voltage_proportional_gain_A_per_V = 0.1;
+voltage_integral_gain_A_per_Vs = 10;
+current_proportional_gain_Ohm = 3;
+minimum_current_reference_A = 0;
+maximum_current_reference_A = 40;
+minimum_duty_cycle = 0.05;
+maximum_duty_cycle = 0.95;
+
+time_s = (0:time_step_s:end_time_s)';
+sample_count = numel(time_s);
+reference_voltage_V = initial_reference_V * ones(sample_count, 1);
+reference_voltage_V(time_s >= reference_step_time_s) = final_reference_V;
+
+output_voltage_V = zeros(sample_count, 1);
+inductor_current_A = zeros(sample_count, 1);
+current_reference_A = zeros(sample_count, 1);
+duty_cycle = zeros(sample_count, 1);
+
+output_voltage_V(1) = initial_reference_V;
+inductor_current_A(1) = initial_reference_V / load_resistance_Ohm;
+voltage_integral_action_A = 0;
+
+for sample = 1:(sample_count - 1)
+    voltage_error_V = reference_voltage_V(sample) - ...
+        output_voltage_V(sample);
+    unconstrained_current_reference_A = ...
+        reference_voltage_V(sample) / load_resistance_Ohm + ...
+        voltage_proportional_gain_A_per_V * voltage_error_V + ...
+        voltage_integral_action_A;
+    current_reference_A(sample) = min(max(...
+        unconstrained_current_reference_A, minimum_current_reference_A), ...
+        maximum_current_reference_A);
+
+    upper_limit_recovery = unconstrained_current_reference_A >= ...
+        maximum_current_reference_A && voltage_error_V < 0;
+    lower_limit_recovery = unconstrained_current_reference_A <= ...
+        minimum_current_reference_A && voltage_error_V > 0;
+    current_reference_is_free = unconstrained_current_reference_A > ...
+        minimum_current_reference_A && unconstrained_current_reference_A < ...
+        maximum_current_reference_A;
+    if current_reference_is_free || upper_limit_recovery || lower_limit_recovery
+        voltage_integral_action_A = voltage_integral_action_A + ...
+            voltage_integral_gain_A_per_Vs * voltage_error_V * time_step_s;
+    end
+
+    current_error_A = current_reference_A(sample) - ...
+        inductor_current_A(sample);
+    unconstrained_duty_cycle = (output_voltage_V(sample) + ...
+        inductor_resistance_Ohm * inductor_current_A(sample) + ...
+        current_proportional_gain_Ohm * current_error_A) / input_voltage_V;
+    duty_cycle(sample) = min(max(unconstrained_duty_cycle, ...
+        minimum_duty_cycle), maximum_duty_cycle);
+
+    current_derivative_A_per_s = (duty_cycle(sample) * input_voltage_V - ...
+        output_voltage_V(sample) - ...
+        inductor_resistance_Ohm * inductor_current_A(sample)) / inductance_H;
+    voltage_derivative_V_per_s = (inductor_current_A(sample) - ...
+        output_voltage_V(sample) / load_resistance_Ohm) / capacitance_F;
+
+    inductor_current_A(sample + 1) = inductor_current_A(sample) + ...
+        time_step_s * current_derivative_A_per_s;
+    output_voltage_V(sample + 1) = output_voltage_V(sample) + ...
+        time_step_s * voltage_derivative_V_per_s;
+end
+
+final_voltage_error_V = reference_voltage_V(end) - output_voltage_V(end);
+current_reference_A(end) = min(max(reference_voltage_V(end) / ...
+    load_resistance_Ohm + voltage_proportional_gain_A_per_V * ...
+    final_voltage_error_V + voltage_integral_action_A, ...
+    minimum_current_reference_A), maximum_current_reference_A);
+final_current_error_A = current_reference_A(end) - inductor_current_A(end);
+duty_cycle(end) = min(max((output_voltage_V(end) + ...
+    inductor_resistance_Ohm * inductor_current_A(end) + ...
+    current_proportional_gain_Ohm * final_current_error_A) / input_voltage_V, ...
+    minimum_duty_cycle), maximum_duty_cycle);
+
+result.time_s = time_s;
+result.reference_voltage_V = reference_voltage_V;
+result.output_voltage_V = output_voltage_V;
+result.inductor_current_A = inductor_current_A;
+result.current_reference_A = current_reference_A;
+result.duty_cycle = duty_cycle;
+result.reference_step_time_s = reference_step_time_s;
+result.final_reference_V = final_reference_V;
+result.minimum_duty_cycle = minimum_duty_cycle;
+result.maximum_duty_cycle = maximum_duty_cycle;
+result.time_step_s = time_step_s;
+end


### PR DESCRIPTION
## Summary
- add a dynamic averaged buck-converter plant with cascaded voltage/current control
- bound current reference and duty cycle, with conditional outer-loop anti-windup
- add a no-plot regression check for finite states, tracking, overshoot, settling, and limits
- document equations, starter parameters, limitations, and run commands
- include the new check in MATLAB R2026a CI

## Validation
- independent equation-level numerical oracle: 399.49 V final average, 421.90 V peak, 38.6 ms two-percent settling, 0.377-0.529 duty range
- changed-document Markdown lint passed
- all repository Markdown links passed
- workflow Prettier check passed
- `git diff --check` passed

The local MATLAB R2026a installation has no available license, so the draft PR's licensed MathWorks Actions run is the authoritative MATLAB execution gate.