### PR TITLE
Add citation metadata and v0.3 changelog

### DIFF
--- a/.github/workflows/citation-validation.yml
+++ b/.github/workflows/citation-validation.yml
@@ -1,0 +1,28 @@
+name: Citation metadata
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - "CITATION.cff"
+  pull_request:
+    paths:
+      - "CITATION.cff"
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    name: Validate CITATION.cff
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Validate citation metadata
+        uses: citation-file-format/cffconvert-github-action@2.0.0
+        with:
+          args: "--validate"

--- a/.github/workflows/markdown-maintenance.yml
+++ b/.github/workflows/markdown-maintenance.yml
@@ -19,5 +19,5 @@ jobs:
       - name: Check Markdown links
         uses: lycheeverse/lychee-action@v2
         with:
-          args: --verbose --no-progress README.md CONTRIBUTING.md notes/*.md examples/README.md examples/*/README.md
+          args: --verbose --no-progress README.md CHANGELOG.md CONTRIBUTING.md notes/*.md examples/README.md examples/*/README.md
           fail: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,47 @@
+# Changelog
+
+Notable changes to MATLAB Simulink Energy Lab are recorded here. The project
+uses semantic versioning while its public model and validation interfaces are
+still evolving.
+
+## Unreleased
+
+## 0.3.0 - 2026-07-23
+
+### Added
+
+- Exact first- and second-order battery equivalent-circuit simulators with a
+  configurable OCV-SOC table, irregular time intervals, SOC-boundary current
+  limiting, and duty-cycle accounting.
+- Native Simulink references for the first-order, second-order, and coupled
+  electro-thermal battery models, each checked against its MATLAB reference.
+- Reversible entropic heat, temperature-dependent resistance, continuous
+  thermal-limit exposure metrics, and a cooling-conductance sensitivity study.
+- Ideal switching, closed-loop averaged, controller-comparison, and native
+  Simulink buck-converter references.
+- MATLAB R2026a validation in GitHub Actions and a single `run_all_checks`
+  entry point for all twelve no-plot checks.
+- Machine-readable software citation metadata in `CITATION.cff`.
+
+### Changed
+
+- Consolidated plotting and validation scripts around reusable simulators and
+  documented engineering assumptions, units, limitations, and expected output.
+- Expanded contributor guidance with scoped acceptance criteria and an explicit
+  genuine-attribution policy.
+
+### Fixed
+
+- Isolated check-script variable cleanup so the complete validation suite runs
+  instead of terminating after its first script.
+
+## 0.2.0 - 2026-07-19
+
+- Added the first temperature-aware battery model with irreversible electrical
+  heat, lumped cooling, temperature-dependent resistance, and energy-balance
+  validation.
+
+## 0.1.0 - 2026-07-13
+
+- Published the first validated battery RC and averaged-converter examples,
+  engineering review guidance, and no-plot checks.

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,29 @@
+cff-version: 1.2.0
+message: "If you use this software in research or teaching, please cite it using these metadata."
+type: software
+title: "MATLAB Simulink Energy Lab"
+version: "0.3.0"
+date-released: "2026-07-23"
+authors:
+  - family-names: "Khan"
+    given-names: "Mohammad Rezwan"
+    orcid: "https://orcid.org/0000-0002-1532-0598"
+abstract: >-
+  An open collection of inspectable MATLAB and Simulink reference models for
+  lithium-ion battery equivalent circuits, lumped electro-thermal behavior,
+  state-of-charge accounting, cooling sensitivity, and power-electronic
+  converters. The repository pairs explicit engineering assumptions with
+  deterministic no-plot validation checks.
+keywords:
+  - "battery thermal management"
+  - "lithium-ion battery"
+  - "equivalent-circuit modeling"
+  - "state of charge"
+  - "energy storage"
+  - "power electronics"
+  - "engineering education"
+  - "MATLAB"
+  - "Simulink"
+license: MIT
+repository-code: "https://github.com/mohammadrezwankhan/matlab-simulink-energy-lab"
+url: "https://github.com/mohammadrezwankhan/matlab-simulink-energy-lab"

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![Markdown maintenance](https://github.com/mohammadrezwankhan/matlab-simulink-energy-lab/actions/workflows/markdown-maintenance.yml/badge.svg)](https://github.com/mohammadrezwankhan/matlab-simulink-energy-lab/actions/workflows/markdown-maintenance.yml)
 [![MATLAB validation](https://github.com/mohammadrezwankhan/matlab-simulink-energy-lab/actions/workflows/matlab-validation.yml/badge.svg)](https://github.com/mohammadrezwankhan/matlab-simulink-energy-lab/actions/workflows/matlab-validation.yml)
 ![MATLAB R2026a](https://img.shields.io/badge/verified-MATLAB%20R2026a-e86e25.svg)
+[![Latest release](https://img.shields.io/github/v/release/mohammadrezwankhan/matlab-simulink-energy-lab)](https://github.com/mohammadrezwankhan/matlab-simulink-energy-lab/releases/latest)
 [![License: MIT](https://img.shields.io/badge/license-MIT-2f6f5e.svg)](LICENSE)
 [![GitHub stars](https://img.shields.io/github/stars/mohammadrezwankhan/matlab-simulink-energy-lab?style=social)](https://github.com/mohammadrezwankhan/matlab-simulink-energy-lab)
 
@@ -247,6 +248,17 @@ between table-schema design, implementation, validation, and documentation.
 Before starting, comment on the issue with the part you want to tackle. The
 [contribution guide](CONTRIBUTING.md) explains the local checks, modeling
 standard, pull request workflow, and attribution policy.
+
+## Releases and Citation
+
+Versioned snapshots and engineering highlights are available on the
+[releases page](https://github.com/mohammadrezwankhan/matlab-simulink-energy-lab/releases).
+See the [changelog](CHANGELOG.md) for the model and validation history.
+
+If you use the lab in research, coursework, or teaching material, use GitHub's
+**Cite this repository** control to export APA or BibTeX metadata. The source
+metadata, including the author's ORCID, is available in
+[`CITATION.cff`](CITATION.cff).
 
 ## Contributing
 


### PR DESCRIPTION
## Summary

- add CFF 1.2.0 software citation metadata with the maintainer's ORCID
- add a v0.3.0 changelog covering the validated model expansion since v0.2.0
- expose release and citation entry points from the README
- validate future citation changes in GitHub Actions and include the changelog in link checks

## Why

The repository is intended for research and teaching, but it did not expose machine-readable citation metadata. GitHub can render a **Cite this repository** control from `CITATION.cff`, making APA and BibTeX export available to visitors and supplying reusable metadata to research-software tools.

The accumulated battery, thermal, Simulink, converter, and validation work since v0.2.0 also needs one auditable release record before publishing v0.3.0.

## Validation

- `cffconvert` 2.0.0 schema validation: valid CFF 1.2.0
- rendered APA output with the expected author, title, version, year, and repository URL
- `npx --yes markdownlint-cli2 README.md CHANGELOG.md`: 0 issues
- `git diff --cached --check`
