### PR TITLE
Prepare v0.4.0 SOC-EKF release metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ still evolving.
 
 ## Unreleased
 
+## 0.4.0 - 2026-07-23
+
 ### Added
 
 - A toolbox-free two-state extended Kalman filter that estimates battery SOC

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,7 +2,7 @@ cff-version: 1.2.0
 message: "If you use this software in research or teaching, please cite it using these metadata."
 type: software
 title: "MATLAB Simulink Energy Lab"
-version: "0.3.0"
+version: "0.4.0"
 date-released: "2026-07-23"
 authors:
   - family-names: "Khan"
@@ -11,14 +11,15 @@ authors:
 abstract: >-
   An open collection of inspectable MATLAB and Simulink reference models for
   lithium-ion battery equivalent circuits, lumped electro-thermal behavior,
-  state-of-charge accounting, cooling sensitivity, and power-electronic
-  converters. The repository pairs explicit engineering assumptions with
-  deterministic no-plot validation checks.
+  real-time extended Kalman filter state-of-charge estimation, cooling
+  sensitivity, and power-electronic converters. The repository pairs explicit
+  engineering assumptions with deterministic no-plot validation checks.
 keywords:
   - "battery thermal management"
   - "lithium-ion battery"
   - "equivalent-circuit modeling"
   - "state of charge"
+  - "extended Kalman filter"
   - "energy storage"
   - "power electronics"
   - "engineering education"


### PR DESCRIPTION
## Summary

- move the merged battery SOC EKF notes into the `0.4.0` changelog section
- update `CITATION.cff` to version `0.4.0`
- add real-time extended Kalman filter SOC estimation to the citation abstract and keywords

## Validation

- `git diff --check` passes
- the pull request citation workflow will validate the complete CFF 1.2 document