### PR TITLE
Prepare v0.5.0 cooling-network release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ still evolving.
 
 ## Unreleased
 
+## 0.5.0 - 2026-07-23
+
 ### Added
 
 - A toolbox-free six-cell battery module thermal network with serial coolant

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,7 +2,7 @@ cff-version: 1.2.0
 message: "If you use this software in research or teaching, please cite it using these metadata."
 type: software
 title: "MATLAB Simulink Energy Lab"
-version: "0.4.0"
+version: "0.5.0"
 date-released: "2026-07-23"
 authors:
   - family-names: "Khan"
@@ -11,11 +11,13 @@ authors:
 abstract: >-
   An open collection of inspectable MATLAB and Simulink reference models for
   lithium-ion battery equivalent circuits, lumped electro-thermal behavior,
-  real-time extended Kalman filter state-of-charge estimation, cooling
-  sensitivity, and power-electronic converters. The repository pairs explicit
-  engineering assumptions with deterministic no-plot validation checks.
+  real-time extended Kalman filter state-of-charge estimation, six-cell module
+  liquid-cooling networks, cooling sensitivity, and power-electronic
+  converters. The repository pairs explicit engineering assumptions with
+  deterministic no-plot validation checks.
 keywords:
   - "battery thermal management"
+  - "battery liquid cooling"
   - "lithium-ion battery"
   - "equivalent-circuit modeling"
   - "state of charge"


### PR DESCRIPTION
## Summary

- promote the validated six-cell battery module liquid-cooling network from Unreleased to v0.5.0
- update `CITATION.cff` to version 0.5.0
- add the liquid-cooling network to the citation abstract and keywords

## Why

The cooling-network feature is merged and fully documented, but the repository's release and citation metadata still describe v0.4.0. This keeps the changelog, GitHub citation panel, and upcoming release aligned with the code users receive.

## Validation

- `git diff --check`
- complete local MATLAB/Simulink gate: all 14 checks passed
- `CITATION.cff` is validated by the repository's citation workflow