### PR TITLE
Prepare v0.6.0 release metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ still evolving.
 
 ## Unreleased
 
+## 0.6.0 - 2026-07-23
+
 ### Added
 
 - A toolbox-free one-dimensional pouch-cell finite-volume model with

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,7 +2,7 @@ cff-version: 1.2.0
 message: "If you use this software in research or teaching, please cite it using these metadata."
 type: software
 title: "MATLAB Simulink Energy Lab"
-version: "0.5.0"
+version: "0.6.0"
 date-released: "2026-07-23"
 authors:
   - family-names: "Khan"
@@ -12,12 +12,16 @@ abstract: >-
   An open collection of inspectable MATLAB and Simulink reference models for
   lithium-ion battery equivalent circuits, lumped electro-thermal behavior,
   real-time extended Kalman filter state-of-charge estimation, six-cell module
-  liquid-cooling networks, cooling sensitivity, and power-electronic
-  converters. The repository pairs explicit engineering assumptions with
-  deterministic no-plot validation checks.
+  liquid-cooling networks, pouch-cell through-thickness finite-volume thermal
+  gradients, cooling sensitivity, and power-electronic converters. The
+  repository pairs explicit engineering assumptions with deterministic
+  no-plot validation checks.
 keywords:
   - "battery thermal management"
   - "battery liquid cooling"
+  - "pouch cell"
+  - "finite volume method"
+  - "thermal gradient"
   - "lithium-ion battery"
   - "equivalent-circuit modeling"
   - "state of charge"


### PR DESCRIPTION
## Summary

Prepare the metadata for the `v0.6.0` release of MATLAB Simulink Energy Lab.

- move the merged pouch-cell finite-volume model from `Unreleased` into `0.6.0`;
- update the software citation version; and
- add entity-rich pouch-cell, finite-volume, and thermal-gradient terms to the citation abstract and keywords.

## Modeling Value

- [ ] Adds a reproducible example.
- [x] Clarifies assumptions.
- [x] Improves setup instructions.
- [x] Adds validation or expected-output notes.

## Validation

```text
uvx --from cffconvert cffconvert --validate
Citation metadata are valid according to schema version 1.2.0.

npx --yes markdownlint-cli2 CHANGELOG.md
0 issues

git diff --check
passed
```

The complete 15-check MATLAB/Simulink validation and link check already passed on the merged model PR #101.

## Review Checklist

- [x] Assumptions, units, sign conventions, and limitations are stated in the released model documentation.
- [x] Required MATLAB products are listed.
- [x] Expected results are described and reproducible.
- [x] New behavior has a deterministic no-plot check.
- [x] No generated artifacts are added by this metadata-only change.
- [x] Documentation reflects the released model and version.

## Collaboration and Attribution

No co-authors. No attribution trailer is present.