### PR TITLE
docs: summarize validation evidence

### DIFF
--- a/.github/workflows/markdown-maintenance.yml
+++ b/.github/workflows/markdown-maintenance.yml
@@ -19,5 +19,5 @@ jobs:
       - name: Check Markdown links
         uses: lycheeverse/lychee-action@v2
         with:
-          args: --verbose --no-progress README.md CHANGELOG.md CONTRIBUTING.md notes/*.md examples/README.md examples/*/README.md examples/bess-unified-control/**/*.md
+          args: --verbose --no-progress README.md CHANGELOG.md CONTRIBUTING.md docs/*.md notes/*.md examples/README.md examples/*/README.md examples/bess-unified-control/**/*.md
           fail: true

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ study.
 - [Models at a Glance](#models-at-a-glance) for the model-to-question map.
 - [Requirements](#requirements) for MATLAB and toolbox expectations.
 - [Scope and Limitations](#scope-and-limitations) before reusing outputs.
+- [Validation results](docs/validation-results.md) for the complete expected output.
 - [Contribute a Scoped Improvement](#contribute-a-scoped-improvement) for focused changes.
 - [Citation metadata](CITATION.cff) and [release notes](CHANGELOG.md) for published or shared work.
 
@@ -95,87 +96,25 @@ cd matlab-simulink-energy-lab
 matlab -batch "addpath('examples'); run_all_checks"
 ```
 
-Expected output:
+### Concise validation evidence
 
-```text
-Battery RC check passed. Final SOC: 0.767
-Voltage range: 3.425 V to 3.877 V
-Native Simulink battery RC check passed.
-Final SOC: 0.767
-Voltage range: 3.425 V to 3.877 V
-Battery 2RC check passed. Final SOC: 0.767
-Voltage range: 3.325 V to 3.925 V
-Peak polarization: fast 0.075 V, slow 0.125 V
-Battery 2RC identification check passed.
-Calibration RMSE: 0.401 mV
-Held-out RMSE: 0.440 mV
-Estimated time constants: 2.01 s and 33.88 s
-Native Simulink battery 2RC check passed.
-Final SOC: 0.767
-Voltage range: 3.325 V to 3.925 V
-Battery SOC EKF check passed.
-Initial prior SOC error: -0.200
-First posterior SOC error: -0.142
-Final SOC error: +0.0001
-SOC RMSE: 0.0066
-Two-percent settling time: 18 s
-Posterior voltage RMSE: 1.581 mV
-Battery OCV hysteresis check passed.
-Final SOC: 0.600
-Hysteresis state range: -0.777 to 0.676
-Same-SOC minor-loop voltage gap: 8.13 mV
-Battery thermal check passed.
-Peak cell temperature: 36.92 degC
-Final cell temperature: 28.96 degC
-Peak irreversible heat: 33.31 W
-Reversible heat range: -2.31 W to 1.12 W
-Peak total heat: 34.29 W
-Final SOC: 0.608
-Battery cooling-sensitivity check passed.
-hA (W/K)  Peak (degC)  Final (degC)  Time > 35.0 degC (s)  Degree-hours
-     0.0        42.73         42.73                1399.6        2.5049
-     0.6        38.89         33.25                1019.7        0.5032
-     1.2        36.92         28.96                 305.6        0.0815
-     2.4        34.05         26.02                   0.0        0.0000
-     4.8        30.78         25.12                   0.0        0.0000
-Battery module cooling-network check passed.
-Peak cell temperature: 39.87 degC (cell 4 at 1320 s)
-Peak cell-temperature spread: 5.10 degC
-Peak coolant outlet temperature: 31.27 degC
-Peak cell temperature at 3x flow: 38.01 degC
-Pouch-cell thermal-gradient check passed.
-Peak node temperature: 43.83 degC at 5.60 mm and 1800 s
-Peak through-thickness node spread: 3.09 degC
-Symmetric steady center error: 0.003 degC
-Medium-to-fine grid center difference: 0.0024 degC
-Native Simulink battery thermal check passed.
-Peak cell temperature: 36.92 degC
-Final cell temperature: 28.96 degC
-Reversible heat range: -2.31 W to 1.12 W
-Converter parameter check passed.
-Output voltage: 360.0 V
-Load current: 18.0 A
-Closed-loop converter check passed.
-Final average voltage: 399.49 V
-Peak voltage after step: 421.90 V
-Two-percent settling time: 38.6 ms
-Controller comparison check passed.
-Controller      Steady error (V)  Overshoot (%)  Settling (ms)  Duty range
-Open loop                  1.984           3.84           20.6  0.502 to 0.502
-PI                        -0.000           1.25           10.3  0.464 to 0.510
-Filtered PID              -0.015           1.67           14.0  0.471 to 0.526
-Switching buck converter check passed.
-Average output voltage: 358.209 V
-Average inductor current: 17.910 A
-Current ripple: 9.901 A peak-to-peak
-Voltage ripple: 0.124 V peak-to-peak
-Measured duty cycle: 0.450
-Native Simulink averaged buck check passed.
-Final output voltage: 358.209 V
-Final inductor current: 17.910 A
-All 31 focused BESS controller tests passed.
-All 18 MATLAB and Simulink checks passed.
-```
+The latest published validation snapshot is release [`v0.9.0`](https://github.com/mohammadrezwankhan/matlab-simulink-energy-lab/releases/tag/v0.9.0).
+The verified MATLAB R2026a run reports:
+
+| Evidence | Result |
+| --- | --- |
+| Repository regression | All 18 MATLAB and Simulink check entry points pass. |
+| Two-RC identification (synthetic) | 0.440 mV held-out voltage RMSE; 0.401 mV calibration RMSE. |
+| SOC EKF (synthetic) | 0.0066 SOC RMSE; 1.581 mV posterior voltage RMSE. |
+| Unified BESS focused suite | 31 focused MATLAB/Simulink results pass across eight mandatory scenarios. |
+| Environment | MATLAB R2026a; Simulink is required for generated diagrams. |
+
+These are deterministic regression checks for reduced-order educational models,
+not physical-cell, hardware, or grid-code validation. In particular, the
+two-RC identification benchmark uses transparent synthetic voltage records with
+deterministic sensor-like perturbations, not measured cell data. See the
+[full expected output and provenance](docs/validation-results.md) and
+[Scope and Limitations](#scope-and-limitations) before reusing results.
 
 To reproduce the plotted battery response above, run:
 
@@ -255,6 +194,7 @@ the [modeling standards](notes/modeling-standards.md).
 ```text
 matlab-simulink-energy-lab/
 |-- assets/                         # Result images used in the documentation
+|-- docs/                           # Full expected validation output
 |-- examples/
 |   |-- battery-rc-model/           # RC simulation, pulse data, and check
 |   |-- battery-simulink-model/     # Generated native battery RC diagram

--- a/docs/validation-results.md
+++ b/docs/validation-results.md
@@ -1,0 +1,118 @@
+<!-- markdownlint-disable MD013 -->
+
+# Validation Results
+
+This page keeps the complete expected output for the repository regression
+command in one place. The README contains only a concise evidence summary so
+the runnable path stays easy to scan.
+
+## Reproduce the check
+
+From the repository root, run:
+
+```bash
+matlab -batch "addpath('examples'); run_all_checks"
+```
+
+The verified environment is MATLAB R2026a. Simulink is required for the native
+block-diagram checks. The latest published validation snapshot is the signed
+[`v0.9.0` release](https://github.com/mohammadrezwankhan/matlab-simulink-energy-lab/releases/tag/v0.9.0).
+
+## Expected output
+
+```text
+Battery RC check passed. Final SOC: 0.767
+Voltage range: 3.425 V to 3.877 V
+Native Simulink battery RC check passed.
+Final SOC: 0.767
+Voltage range: 3.425 V to 3.877 V
+Battery 2RC check passed. Final SOC: 0.767
+Voltage range: 3.325 V to 3.925 V
+Peak polarization: fast 0.075 V, slow 0.125 V
+Battery 2RC identification check passed.
+Calibration RMSE: 0.401 mV
+Held-out RMSE: 0.440 mV
+Estimated time constants: 2.01 s and 33.88 s
+Native Simulink battery 2RC check passed.
+Final SOC: 0.767
+Voltage range: 3.325 V to 3.925 V
+Battery SOC EKF check passed.
+Initial prior SOC error: -0.200
+First posterior SOC error: -0.142
+Final SOC error: +0.0001
+SOC RMSE: 0.0066
+Two-percent settling time: 18 s
+Posterior voltage RMSE: 1.581 mV
+Battery OCV hysteresis check passed.
+Final SOC: 0.600
+Hysteresis state range: -0.777 to 0.676
+Same-SOC minor-loop voltage gap: 8.13 mV
+Battery thermal check passed.
+Peak cell temperature: 36.92 degC
+Final cell temperature: 28.96 degC
+Peak irreversible heat: 33.31 W
+Reversible heat range: -2.31 W to 1.12 W
+Peak total heat: 34.29 W
+Final SOC: 0.608
+Battery cooling-sensitivity check passed.
+hA (W/K)  Peak (degC)  Final (degC)  Time > 35.0 degC (s)  Degree-hours
+     0.0        42.73         42.73                1399.6        2.5049
+     0.6        38.89         33.25                1019.7        0.5032
+     1.2        36.92         28.96                 305.6        0.0815
+     2.4        34.05         26.02                   0.0        0.0000
+     4.8        30.78         25.12                   0.0        0.0000
+Battery module cooling-network check passed.
+Peak cell temperature: 39.87 degC (cell 4 at 1320 s)
+Peak cell-temperature spread: 5.10 degC
+Peak coolant outlet temperature: 31.27 degC
+Peak cell temperature at 3x flow: 38.01 degC
+Pouch-cell thermal-gradient check passed.
+Peak node temperature: 43.83 degC at 5.60 mm and 1800 s
+Peak through-thickness node spread: 3.09 degC
+Symmetric steady center error: 0.003 degC
+Medium-to-fine grid center difference: 0.0024 degC
+Native Simulink battery thermal check passed.
+Peak cell temperature: 36.92 degC
+Final cell temperature: 28.96 degC
+Reversible heat range: -2.31 W to 1.12 W
+Converter parameter check passed.
+Output voltage: 360.0 V
+Load current: 18.0 A
+Closed-loop converter check passed.
+Final average voltage: 399.49 V
+Peak voltage after step: 421.90 V
+Two-percent settling time: 38.6 ms
+Controller comparison check passed.
+Controller      Steady error (V)  Overshoot (%)  Settling (ms)  Duty range
+Open loop                  1.984           3.84           20.6  0.502 to 0.502
+PI                        -0.000           1.25           10.3  0.464 to 0.510
+Filtered PID              -0.015           1.67           14.0  0.471 to 0.526
+Switching buck converter check passed.
+Average output voltage: 358.209 V
+Average inductor current: 17.910 A
+Current ripple: 9.901 A peak-to-peak
+Voltage ripple: 0.124 V peak-to-peak
+Measured duty cycle: 0.450
+Native Simulink averaged buck check passed.
+Final output voltage: 358.209 V
+Final inductor current: 17.910 A
+All 31 focused BESS controller tests passed.
+All 18 MATLAB and Simulink checks passed.
+```
+
+## Interpretation and limits
+
+- These outputs are deterministic regression evidence for reduced-order,
+  educational engineering models. They are not physical-cell, hardware, or
+  grid-code qualification results.
+- The two-RC identification benchmark uses transparent synthetic voltage
+  records with deterministic sensor-like perturbations. Its held-out RMSE is
+  not validation against measured physical-cell data.
+- Recalibrate parameters and revalidate expected outputs before applying any
+  model to real cells, converters, or control designs. See the repository's
+  [Scope and Limitations](../README.md#scope-and-limitations).
+
+For the focused BESS scenarios, see the detailed
+[Unified BESS validation report](../examples/bess-unified-control/validation/validation-report.md),
+which records the eight mandatory scenarios, 31 focused results, environment,
+and publication evidence.


### PR DESCRIPTION
Summary: Replace the long README output dump with concise, versioned validation evidence; preserve the complete output and provenance in docs/validation-results.md; keep the physical-cell validation gap explicit. Validation: markdownlint, link checks, diff check, exact output preservation. MATLAB was not rerun locally.