### PR TITLE
Docs: prepare v0.10.0 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ Notable changes to MATLAB Simulink Energy Lab are recorded here. The project
 uses semantic versioning while its public model and validation interfaces are
 still evolving.
 
+## 0.10.0 - 2026-08-19
+
+### Added
+
+- A source-linked two-RC battery parameter-identification tutorial that
+  distinguishes calibration from independent held-out pulse validation and
+  documents the synthetic benchmark boundary.
+- A grid-forming BESS control walkthrough covering grid-following operation,
+  grid loss, islanded support, synchronization, reconnection, limits, fault
+  behavior, and recovery, with direct links to executable evidence.
+
+### Changed
+
+- Refined repository discovery metadata and the README documentation map so
+  MATLAB/Simulink users can reach the validated battery and BESS workflows
+  from the project landing page.
+
 ## 0.9.0 - 2026-07-28
 
 ### Added


### PR DESCRIPTION
## What changed

Adds the `0.10.0` changelog entry for the two-RC held-out-validation and grid-forming BESS tutorials already merged on `main`.

## Why

The latest public release is `v0.9.0`; documenting the post-release tutorials gives visitors a clear, versioned record of what is available.

## Validation

- `git diff --check`
- Changelog entries link only to work already present on `main`; no model code or validation behavior changes.