### PR TITLE
Security: harden current CI action references

### DIFF
--- a/.github/workflows/citation-validation.yml
+++ b/.github/workflows/citation-validation.yml
@@ -18,11 +18,14 @@ jobs:
   validate:
     name: Validate CITATION.cff
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          persist-credentials: false
 
       - name: Validate citation metadata
-        uses: citation-file-format/cffconvert-github-action@2.0.0
+        uses: citation-file-format/cffconvert-github-action@4cf11baa70a673bfdf9dad0acc7ee33b3f4b6084 # 2.0.0
         with:
           args: "--validate"

--- a/.github/workflows/markdown-maintenance.yml
+++ b/.github/workflows/markdown-maintenance.yml
@@ -12,12 +12,15 @@ permissions:
 jobs:
   link-check:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          persist-credentials: false
 
       - name: Check Markdown links
-        uses: lycheeverse/lychee-action@v2
+        uses: lycheeverse/lychee-action@e7477775783ea5526144ba13e8db5eec57747ce8 # v2
         with:
           args: --verbose --no-progress README.md CHANGELOG.md CONTRIBUTING.md docs/*.md notes/*.md examples/README.md examples/*/README.md examples/bess-unified-control/**/*.md
           fail: true

--- a/.github/workflows/matlab-validation.yml
+++ b/.github/workflows/matlab-validation.yml
@@ -31,16 +31,18 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          persist-credentials: false
 
       - name: Set up MATLAB R2026a
-        uses: matlab-actions/setup-matlab@v3
+        uses: matlab-actions/setup-matlab@2323adb8243827ea460b0def4c413545aaec46a9 # v3
         with:
           release: R2026a
           products: Simulink
 
       - name: Run model checks
-        uses: matlab-actions/run-command@v3
+        uses: matlab-actions/run-command@75644028e1e2aa374bbfdc968a65718a178cc264 # v3
         with:
           command: addpath('examples'); run_all_checks(false)
 
@@ -50,26 +52,28 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          persist-credentials: false
 
       - name: Set up MATLAB R2026a
-        uses: matlab-actions/setup-matlab@v3
+        uses: matlab-actions/setup-matlab@2323adb8243827ea460b0def4c413545aaec46a9 # v3
         with:
           release: R2026a
           products: Simulink
 
       - name: Run focused unified BESS checks
-        uses: matlab-actions/run-command@v3
+        uses: matlab-actions/run-command@75644028e1e2aa374bbfdc968a65718a178cc264 # v3
         with:
           command: addpath('examples/bess-unified-control'); run('examples/bess-unified-control/check_bess_unified_control.m')
 
       - name: Generate commit-bound BESS evidence
-        uses: matlab-actions/run-command@v3
+        uses: matlab-actions/run-command@75644028e1e2aa374bbfdc968a65718a178cc264 # v3
         with:
           command: addpath('examples/bess-unified-control'); generate_bess_validation_evidence(getenv('GITHUB_SHA'))
 
       - name: Upload BESS validation evidence
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: bess-validation-${{ github.sha }}
           path: |

--- a/.github/workflows/no-codex-attribution.yml
+++ b/.github/workflows/no-codex-attribution.yml
@@ -15,7 +15,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Check out full history
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           fetch-depth: 0
           persist-credentials: false


### PR DESCRIPTION
## What changed

- Pins every external GitHub Action in the citation, Markdown, MATLAB, and authorship workflows to a full commit SHA.
- Disables persisted checkout credentials where the workflow only reads repository content.
- Adds bounded timeouts to the citation and Markdown jobs.
- Preserves the current `docs/*.md` link-check scope and the expanded human-authorship policy on `main`.

## Why

PR #117 proposed useful CI supply-chain hardening but became conflicted as the workflows evolved. This replacement reapplies the still-relevant controls to current `main` using the commits currently resolved by each action's official major tag.

## Validation

- `git diff --check`
- Verified all external `uses:` references are pinned to 40-character commit SHAs.
- Resolved each SHA through the action repository's official GitHub API commit endpoint.

Supersedes #117.
