### PR TITLE
Docs: add focused community contribution forms

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,81 @@
+name: Bug report
+description: Report a reproducible problem in an example, script, model, or check.
+title: "Bug: "
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for helping improve the Energy Lab. Remove proprietary data and credentials before submitting.
+  - type: dropdown
+    id: area
+    attributes:
+      label: Affected area
+      options:
+        - Battery models
+        - Converter models
+        - BESS control
+        - Simulink model generation
+        - Validation or CI
+        - Documentation
+        - Other
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: Release or commit
+      description: Provide a release tag or full commit SHA.
+      placeholder: v0.10.0 or 4626b7b...
+    validations:
+      required: true
+  - type: textarea
+    id: summary
+    attributes:
+      label: Problem summary
+      description: Describe the observed problem and its engineering impact.
+    validations:
+      required: true
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Minimal reproduction
+      description: List exact commands, scripts, model steps, and inputs needed to reproduce the problem.
+      placeholder: |
+        1. Run ...
+        2. Open ...
+        3. Observe ...
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior and evidence
+      description: Include concise logs, error identifiers, or screenshots without sensitive data.
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Include OS, MATLAB release, Simulink release, and relevant toolboxes.
+    validations:
+      required: true
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Submission checks
+      options:
+        - label: I searched existing issues and did not find the same problem.
+          required: true
+        - label: I can reproduce this from the stated release or commit.
+          required: true
+        - label: I removed proprietary data, secrets, and personal information.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Technical discussions
+    url: https://github.com/mohammadrezwankhan/matlab-simulink-energy-lab/discussions
+    about: Ask usage questions and discuss ideas that are not yet scoped issues.
+  - name: Private security report
+    url: https://github.com/mohammadrezwankhan/matlab-simulink-energy-lab/security/advisories/new
+    about: Report a suspected vulnerability privately instead of opening a public issue.

--- a/.github/ISSUE_TEMPLATE/dataset_proposal.yml
+++ b/.github/ISSUE_TEMPLATE/dataset_proposal.yml
@@ -1,0 +1,72 @@
+name: Dataset proposal
+description: Propose openly licensed engineering data for a reproducible model or validation workflow.
+title: "Dataset: "
+labels:
+  - enhancement
+  - research-notes
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Propose the source and provenance before preparing an adapter or committing derived data.
+  - type: input
+    id: source
+    attributes:
+      label: Canonical source
+      description: Provide the DOI or durable official record URL.
+      placeholder: https://doi.org/...
+    validations:
+      required: true
+  - type: input
+    id: license
+    attributes:
+      label: License and redistribution terms
+      description: Name the license and link to the authoritative terms.
+    validations:
+      required: true
+  - type: textarea
+    id: protocol
+    attributes:
+      label: Cell, equipment, and test protocol
+      description: Include chemistry, capacity, temperature, sampling, current convention, cutoffs, and rest conditions when applicable.
+    validations:
+      required: true
+  - type: textarea
+    id: schema
+    attributes:
+      label: Files, schema, units, and checksums
+      description: Identify candidate files, columns, units, approximate sizes, and published or computed checksums.
+    validations:
+      required: true
+  - type: textarea
+    id: split
+    attributes:
+      label: Calibration and held-out split
+      description: Explain how the split prevents target leakage and how OCV or initial state is justified independently.
+    validations:
+      required: true
+  - type: textarea
+    id: preprocessing
+    attributes:
+      label: Reproducible preprocessing
+      description: Describe filtering, resampling, fixture derivation, attribution, and deterministic verification.
+    validations:
+      required: true
+  - type: textarea
+    id: limitations
+    attributes:
+      label: Uncertainty and limitations
+      description: State missing metadata, assumptions, and claims the data cannot support.
+    validations:
+      required: true
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Submission checks
+      options:
+        - label: The data is public and its license permits the proposed use or durable download workflow.
+          required: true
+        - label: I have not included proprietary, confidential, or personal data.
+          required: true
+        - label: I will wait for scope review before preparing a pull request.
+          required: true

--- a/.github/ISSUE_TEMPLATE/model_proposal.yml
+++ b/.github/ISSUE_TEMPLATE/model_proposal.yml
@@ -1,0 +1,65 @@
+name: Model or example proposal
+description: Propose a scoped MATLAB or Simulink engineering example with a validation path.
+title: "Proposal: "
+labels:
+  - enhancement
+  - example
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Strong proposals define the engineering question, assumptions, evidence, and a deterministic validation path.
+  - type: textarea
+    id: objective
+    attributes:
+      label: Engineering objective
+      description: What specific behavior, design question, or learning outcome should this example address?
+    validations:
+      required: true
+  - type: textarea
+    id: basis
+    attributes:
+      label: Technical basis and sources
+      description: List governing equations, standards, papers, or official documentation and distinguish facts from assumptions.
+    validations:
+      required: true
+  - type: textarea
+    id: scope
+    attributes:
+      label: Proposed scope
+      description: Identify expected MATLAB files, Simulink components, inputs, outputs, and explicit exclusions.
+    validations:
+      required: true
+  - type: textarea
+    id: validation
+    attributes:
+      label: Deterministic validation plan
+      description: Define executable checks, reference values, tolerances, and failure conditions.
+    validations:
+      required: true
+  - type: textarea
+    id: limitations
+    attributes:
+      label: Assumptions, limitations, and safety boundary
+      description: State what the model does not validate, including certification or hardware claims.
+    validations:
+      required: true
+  - type: dropdown
+    id: contribution
+    attributes:
+      label: Contribution intent
+      options:
+        - I can prepare a pull request after scope review
+        - I can help test or review
+        - I am proposing the idea only
+    validations:
+      required: true
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Submission checks
+      options:
+        - label: I searched existing issues, examples, and discussions for overlap.
+          required: true
+        - label: The proposal has standalone technical value and is not promotional content.
+          required: true

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,47 @@
+# Code of Conduct
+
+## Our pledge
+
+We pledge to make participation in this project a harassment-free experience
+for everyone, regardless of background, identity, experience level, or personal
+characteristics. We will act in ways that support an open, welcoming, inclusive,
+and technically constructive community.
+
+## Expected behavior
+
+- Be respectful of different viewpoints and experience levels.
+- Give specific, evidence-based, and constructive technical feedback.
+- Accept responsibility, correct mistakes, and acknowledge contributions.
+- Keep discussions focused on the engineering work and the public interest.
+- Respect privacy, licenses, attribution, and project safety boundaries.
+
+## Unacceptable behavior
+
+- Harassment, threats, discrimination, or unwanted sexual attention.
+- Insults, trolling, personal or political attacks, or sustained disruption.
+- Publishing another person's private information without permission.
+- Knowingly submitting proprietary data, credentials, or malicious content.
+- Conduct that would reasonably be considered inappropriate in a professional
+  engineering community.
+
+## Scope
+
+This code applies in repository issues, pull requests, discussions, reviews,
+and other spaces where someone represents this project.
+
+## Reporting and enforcement
+
+Report unacceptable behavior through a private contact method listed on the
+maintainer's [GitHub profile](https://github.com/mohammadrezwankhan). Do not
+disclose sensitive incident details in a public issue.
+
+The maintainer will review reports promptly and fairly, protect reporters'
+privacy, and may edit or remove content, issue a warning, temporarily restrict
+participation, or permanently ban participants when necessary. Enforcement will
+be proportional to the severity, impact, and pattern of the conduct.
+
+## Attribution
+
+This policy is informed by the [Contributor Covenant](https://www.contributor-covenant.org/)
+and its community-impact approach, adapted to this repository's engineering and
+data-provenance context.


### PR DESCRIPTION
## What changed

- add focused GitHub issue forms for reproducible bugs, model/example proposals, and openly licensed dataset proposals
- route usage questions to Discussions and suspected vulnerabilities to private security advisories
- add a repository-specific code of conduct with private reporting guidance

## Why

The repository had no structured issue templates or code of conduct. The new forms ask for the engineering evidence, provenance, validation plan, and safety boundaries needed to turn genuine interest into reviewable contributions without encouraging generic promotion.

## Impact

Contributors receive clearer paths for reporting problems and proposing technically scoped work. Maintainers receive reproducible environment details, explicit validation criteria, and dataset licensing/provenance information at intake.

## Checks

- parsed every `.github/ISSUE_TEMPLATE/*.yml` file with PyYAML
- `git diff --check`
- verified commit signature through the GitHub API (`verified: true`)