### PR TITLE
Docs: sync citation metadata with v0.10.0

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: "If you use this software in research or teaching, please cite it using these metadata."
 type: software
 title: "MATLAB Simulink Energy Lab"
-version: "0.9.0"
-date-released: "2026-07-28"
+version: "0.10.0"
+date-released: "2026-08-19"
 authors:
   - family-names: "Khan"
     given-names: "Mohammad Rezwan"


### PR DESCRIPTION
## What changed

- update `CITATION.cff` from version 0.9.0 to 0.10.0
- update the citation release date from 2026-07-28 to the published v0.10.0 date, 2026-08-19

## Why

The repository's current GitHub release is v0.10.0, but its machine-readable citation metadata still described v0.9.0. Researchers and citation tooling could therefore produce stale release references.

## Impact

GitHub's citation export and downstream CFF consumers can identify the current release accurately. No model, example, or runtime behavior changes.

## Checks

- `cffconvert --validate`: valid against CFF schema 1.2.0
- `git diff --check`
- GitHub commit verification: valid