### PR TITLE
docs: link verified v0.10.0 download

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,6 +304,9 @@ standard, pull request workflow, and attribution policy.
 
 Versioned snapshots and engineering highlights are available on the
 [releases page](https://github.com/mohammadrezwankhan/matlab-simulink-energy-lab/releases).
+For a checksum-verifiable snapshot, download the tracked
+[v0.10.0 source package](https://github.com/mohammadrezwankhan/matlab-simulink-energy-lab/releases/download/v0.10.0/matlab-simulink-energy-lab-v0.10.0.zip)
+and its published [SHA-256 checksum](https://github.com/mohammadrezwankhan/matlab-simulink-energy-lab/releases/download/v0.10.0/SHA256SUMS-v0.10.0.txt).
 See the [changelog](CHANGELOG.md) for the model and validation history.
 
 If you use the lab in research, coursework, or teaching material, use GitHub's


### PR DESCRIPTION
## What changed

- link the tracked v0.10.0 source package from the README release section
- link its published SHA-256 checksum beside the download

## Why

The release now provides a tag-exact, checksum-verifiable source archive with visible download measurement, but the repository landing page only pointed readers to the generic releases index.

## Validation

- both release-asset URLs returned HTTP 200
- `git diff --check` passed
- the uploaded package digest matches its published checksum
