### PR TITLE
Align the BESS Scenario C quick start

### DIFF
--- a/examples/bess-unified-control/README.md
+++ b/examples/bess-unified-control/README.md
@@ -42,9 +42,15 @@ From the repository root:
 ```matlab
 addpath('examples/bess-unified-control')
 parameters = init_bess_unified_control();
-modelPath = build_bess_unified_control_model();
-run_bess_unified_control('C')
+scenarios = bess_validation_scenarios(parameters);
+scenarioC = scenarios(strcmp({scenarios.id}, 'C'));
+modelPath = build_bess_unified_control_model([], scenarioC, parameters);
+result = run_bess_unified_control('C');
 ```
+
+The builder creates the disposable native Simulink model configured for
+Scenario C. The runner separately simulates and plots the reduced-order MATLAB
+reference for that same scenario; the focused check below compares both paths.
 
 Run the focused no-plot verification:
 

--- a/examples/bess-unified-control/run_bess_unified_control.m
+++ b/examples/bess-unified-control/run_bess_unified_control.m
@@ -1,5 +1,5 @@
 function result = run_bess_unified_control(scenarioIdentifier)
-%RUN_BESS_UNIFIED_CONTROL Build, simulate, and plot one scenario.
+%RUN_BESS_UNIFIED_CONTROL Simulate and plot one MATLAB reference scenario.
 
 if nargin < 1
     scenarioIdentifier = 'C';


### PR DESCRIPTION
## Summary
- configure the generated native BESS model with the same Scenario C plotted by the MATLAB reference runner
- clarify that the runner simulates and plots the MATLAB reference rather than building Simulink
- explain how the focused check compares the two paths

## Validation
- exact documented quick-start block passed in MATLAB R2026a
- all 31 focused BESS controller tests passed
- Code Analyzer returned zero findings for the runner
- git diff --check passed
- two independent read-only reviews returned MERGE

No model physics, validation thresholds, release surfaces, or promotional claims change.