### PR TITLE
Fix standalone BESS evidence reproduction path

### DIFF
--- a/examples/bess-unified-control/docs/reproduction.md
+++ b/examples/bess-unified-control/docs/reproduction.md
@@ -47,6 +47,7 @@ assert(score.passed)
 ## Regenerate evidence
 
 ```matlab
+addpath('examples/bess-unified-control')
 generate_bess_validation_evidence("COMMIT_SHA")
 ```
 


### PR DESCRIPTION
Summary: add the required BESS example directory to the MATLAB path before the standalone evidence generator call in the reproduction guide. Fresh-session evidence: before the change, the documented root command reported generator_exist=0 and exited 1 with an unrecognized function error. With the corrected two-line command, MATLAB R2026a Update 4 generated evidence for all 8 passing scenarios, discovered 31 focused tests, reported 0 analyzer messages, and wrote all three plots. Scope: one documentation line; no model, physics, validation threshold, or generated evidence changed.