### PR TITLE
Upgrade artifact uploads to Node 24 action

### DIFF
--- a/.github/workflows/matlab-validation.yml
+++ b/.github/workflows/matlab-validation.yml
@@ -48,7 +48,7 @@ jobs:
 
       - name: Upload commit-bound validation manifest
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: validation-summary-${{ github.sha }}
           path: validation-artifacts/validation-summary.json
@@ -81,7 +81,7 @@ jobs:
           command: addpath('examples/bess-unified-control'); generate_bess_validation_evidence(getenv('GITHUB_SHA'))
 
       - name: Upload BESS validation evidence
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: bess-validation-${{ github.sha }}
           path: |


### PR DESCRIPTION
Summary: replace both immutable actions/upload-artifact v4 pins with the official v7.0.1 commit 043fb46d, which declares Node.js 24. Evidence: every current main artifact-upload step emits GitHub's Node.js 20 deprecation annotation; the current hosted runner is 2.336.0. The v7 action preserves the name, path, and if-no-files-found inputs used here and keeps archive=true by default. Validation gate: both MATLAB jobs must pass, both exact-commit artifacts must upload, and the Node.js 20 annotation must be absent. No MATLAB code, model, evidence schema, thresholds, or artifact paths change.