### PR TITLE
Make BESS reserve commands work from repository root

### DIFF
--- a/examples/bess-dc-reserve-model/README.md
+++ b/examples/bess-dc-reserve-model/README.md
@@ -60,26 +60,28 @@ controller, or site energy-management algorithm.
 
 ## Run
 
+From the repository root:
+
 ```matlab
-run_bess_dc_reserve
+run('examples/bess-dc-reserve-model/run_bess_dc_reserve.m')
 ```
 
 For the no-plot regression check:
 
 ```matlab
-check_bess_dc_reserve
+run('examples/bess-dc-reserve-model/check_bess_dc_reserve.m')
 ```
 
 For the illustrative reserve-floor versus constant-request sensitivity:
 
 ```matlab
-run_bess_dc_reserve_envelope
+run('examples/bess-dc-reserve-model/run_bess_dc_reserve_envelope.m')
 ```
 
 For the prescribed dynamic-profile sensitivity:
 
 ```matlab
-run_bess_dc_reserve_profile_sensitivity
+run('examples/bess-dc-reserve-model/run_bess_dc_reserve_profile_sensitivity.m')
 ```
 
 [Open the prescribed dynamic-profile runner in MATLAB Online](https://matlab.mathworks.com/open/github/v1?repo=mohammadrezwankhan/matlab-simulink-energy-lab&file=examples/bess-dc-reserve-model/run_bess_dc_reserve_profile_sensitivity.m).


### PR DESCRIPTION
## Summary

- state that the BESS DC-reserve commands run from the repository root
- replace four unresolved bare command names with root-relative `run(...)` calls
- preserve the model, results, tolerances, and technical claims unchanged

## Reproduction

From a fresh repository-root MATLAB R2026a session after `restoredefaultpath`, all four documented bare names returned `exist(name, 'file') == 0`.

## Validation

```text
matlab -batch "restoredefaultpath; run('examples/bess-dc-reserve-model/check_bess_dc_reserve.m'); run('examples/bess-dc-reserve-model/check_bess_dc_reserve_envelope.m'); run('examples/bess-dc-reserve-model/check_bess_dc_reserve_profile_sensitivity.m');"
```

Passed the base check, 18-case constant-request sensitivity, and nine-case prescribed dynamic-profile sensitivity. All four exact replacement README commands also completed from a fresh root session with figures hidden. `git diff --check` passed.

## Scope

Documentation-only first-run repair. No model, parameter, tolerance, generated artifact, dependency, or engineering claim changed.