### PR TITLE
Add one-time exact-commit MATLAB R2025b proof

### DIFF
--- a/.github/workflows/matlab-r2025b-proof.yml
+++ b/.github/workflows/matlab-r2025b-proof.yml
@@ -1,0 +1,104 @@
+name: MATLAB R2025b compatibility proof
+
+on:
+  workflow_dispatch:
+    inputs:
+      source_commit:
+        description: Full 40-character commit SHA to validate
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: matlab-r2025b-proof-${{ inputs.source_commit }}
+  cancel-in-progress: false
+
+jobs:
+  validate-examples-r2025b:
+    name: Validate executable examples on R2025b
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout exact source commit
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          ref: ${{ inputs.source_commit }}
+          persist-credentials: false
+
+      - name: Verify exact source commit
+        env:
+          SOURCE_COMMIT: ${{ inputs.source_commit }}
+        run: |
+          [[ "$SOURCE_COMMIT" =~ ^[0-9a-f]{40}$ ]]
+          test "$(git rev-parse HEAD)" = "$SOURCE_COMMIT"
+
+      - name: Set up MATLAB R2025b
+        uses: matlab-actions/setup-matlab@2323adb8243827ea460b0def4c413545aaec46a9 # v3
+        with:
+          release: R2025b
+          products: Simulink
+
+      - name: Record exact environment
+        uses: matlab-actions/run-command@75644028e1e2aa374bbfdc968a65718a178cc264 # v3
+        with:
+          command: folder='validation-artifacts'; if ~isfolder(folder), mkdir(folder); end; [gitStatus,sourceCommit]=system('git rev-parse HEAD'); assert(gitStatus==0); assert(strcmp(version('-release'),'2025b')); simulinkInfo=ver('simulink'); assert(~isempty(simulinkInfo)); fid=fopen(fullfile(folder,'r2025b-environment.txt'),'w'); assert(fid~=-1); fprintf(fid,'source_commit=%s\nrunner_os=%s\nrunner_image_os=%s\ncomputer=%s\nmatlab_release=%s\nmatlab_version=%s\nsimulink_version=%s\n',strtrim(sourceCommit),getenv('RUNNER_OS'),getenv('ImageOS'),computer,version('-release'),version,simulinkInfo.Version); fclose(fid)
+
+      - name: Run model checks
+        uses: matlab-actions/run-command@75644028e1e2aa374bbfdc968a65718a178cc264 # v3
+        with:
+          command: addpath('examples'); run('examples/validation-manifest/check_validation_manifest.m'); generate_validation_manifest('${{ inputs.source_commit }}')
+
+      - name: Upload R2025b validation manifest
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: r2025b-validation-summary-${{ inputs.source_commit }}
+          path: |
+            validation-artifacts/validation-summary.json
+            validation-artifacts/r2025b-environment.txt
+          if-no-files-found: error
+
+  validate-bess-r2025b:
+    name: Validate unified BESS control on R2025b
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout exact source commit
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          ref: ${{ inputs.source_commit }}
+          persist-credentials: false
+
+      - name: Verify exact source commit
+        env:
+          SOURCE_COMMIT: ${{ inputs.source_commit }}
+        run: |
+          [[ "$SOURCE_COMMIT" =~ ^[0-9a-f]{40}$ ]]
+          test "$(git rev-parse HEAD)" = "$SOURCE_COMMIT"
+
+      - name: Set up MATLAB R2025b
+        uses: matlab-actions/setup-matlab@2323adb8243827ea460b0def4c413545aaec46a9 # v3
+        with:
+          release: R2025b
+          products: Simulink
+
+      - name: Run focused unified BESS checks
+        uses: matlab-actions/run-command@75644028e1e2aa374bbfdc968a65718a178cc264 # v3
+        with:
+          command: assert(strcmp(version('-release'),'2025b')); addpath('examples/bess-unified-control'); run('examples/bess-unified-control/check_bess_unified_control.m')
+
+      - name: Generate commit-bound BESS evidence
+        uses: matlab-actions/run-command@75644028e1e2aa374bbfdc968a65718a178cc264 # v3
+        with:
+          command: addpath('examples/bess-unified-control'); generate_bess_validation_evidence('${{ inputs.source_commit }}')
+
+      - name: Upload R2025b BESS evidence
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: r2025b-bess-validation-${{ inputs.source_commit }}
+          path: |
+            examples/bess-unified-control/validation/results.json
+            examples/bess-unified-control/validation/scenario-*.png
+          if-no-files-found: error


### PR DESCRIPTION
## Summary

Add a temporary, manual-only workflow that can validate one exact repository commit on MATLAB R2025b + Simulink without changing the maintained R2026a workflow.

## Evidence target

The single planned dispatch will validate exact source commit:

`c0a5a2c63772382cd77b156bc8fa328d43820126`

The workflow requires a lowercase 40-character SHA, checks out that SHA, verifies `git rev-parse HEAD`, asserts MATLAB release `2025b`, records exact MATLAB/Simulink/Ubuntu metadata, and produces release/SHA-qualified artifacts.

## Coverage

- 25 general checks and commit-bound validation manifest
- 31 focused unified-BESS results across eight scenarios
- exact environment record
- no change to the R2026a workflow or validation claims

## Safety and lifecycle

- `workflow_dispatch` only
- read-only repository permissions
- immutable action pins
- BESS artifacts upload only after successful R2025b generation, preventing tracked R2026a evidence from being mislabeled
- remove this temporary workflow after the one bounded run

No R2025b compatibility claim will be made unless both hosted jobs and inspected artifacts pass. A failure will be recorded as failure evidence without changing model tolerances or code.