### PR TITLE
ci: validate CodeMeta against citation metadata

### DIFF
--- a/.github/workflows/citation-validation.yml
+++ b/.github/workflows/citation-validation.yml
@@ -32,17 +32,22 @@ jobs:
         with:
           args: "--validate"
 
-      - name: Validate CodeMeta JSON and release identity
+      - name: Validate CodeMeta JSON and CFF consistency
         shell: bash
         run: |
           jq empty codemeta.json
           test "$(jq -r '."@context"' codemeta.json)" = \
             "https://w3id.org/codemeta/3.1"
-          test "$(jq -r '.version' codemeta.json)" = "0.10.0"
-          test "$(jq -r '.datePublished' codemeta.json)" = "2026-08-19"
-          test "$(jq -r '.codeRepository' codemeta.json)" = \
-            "https://github.com/mohammadrezwankhan/matlab-simulink-energy-lab"
-          test "$(jq -r '.license' codemeta.json)" = \
-            "https://spdx.org/licenses/MIT.html"
-          test "$(jq -r '.author."@id"' codemeta.json)" = \
-            "https://orcid.org/0000-0002-1532-0598"
+
+          cff_version="$(sed -n 's/^version: "\(.*\)"/\1/p' CITATION.cff)"
+          cff_date="$(sed -n 's/^date-released: "\(.*\)"/\1/p' CITATION.cff)"
+          cff_repository="$(sed -n 's/^repository-code: "\(.*\)"/\1/p' CITATION.cff)"
+          cff_license="$(sed -n 's/^license: \(.*\)/\1/p' CITATION.cff)"
+          cff_orcid="$(sed -n 's/^    orcid: "\(.*\)"/\1/p' CITATION.cff)"
+
+          test "$(jq -r '.version' codemeta.json)" = "$cff_version"
+          test "$(jq -r '.datePublished' codemeta.json)" = "$cff_date"
+          test "$(jq -r '.codeRepository' codemeta.json)" = "$cff_repository"
+          test "$(jq -r '.url' codemeta.json)" = "$cff_repository"
+          test "$(jq -r '.license' codemeta.json | sed 's#https://spdx.org/licenses/##; s/\.html$//')" = "$cff_license"
+          test "$(jq -r '.author."@id"' codemeta.json)" = "$cff_orcid"

--- a/.github/workflows/citation-validation.yml
+++ b/.github/workflows/citation-validation.yml
@@ -8,10 +8,12 @@ on:
     paths:
       - "CITATION.cff"
       - "codemeta.json"
+      - ".github/workflows/citation-validation.yml"
   pull_request:
     paths:
       - "CITATION.cff"
       - "codemeta.json"
+      - ".github/workflows/citation-validation.yml"
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

Replace release-hardcoded CodeMeta assertions with relational checks against CITATION.cff for version, release date, repository URL, license, and author ORCID. The CodeMeta context remains pinned to 3.1.

## Validation

- YAML lint: pass
- local relational CFF/CodeMeta assertions: pass
- git diff --check: pass